### PR TITLE
[codex] ingest codex-app package

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -158,6 +158,41 @@ Exit criteria:
 
 ## Repo workflow tooling
 
+### Adopt declarative package maintenance policies
+
+This repo has started to need package-specific maintenance policy beyond a
+plain `PKGBUILD` workflow. `codex-app` is the first concrete case: it is built
+by the maintained `codex-app-linux` source repo, and this repo should ingest a
+fresh package artifact when one exists instead of rebuilding it here.
+
+Adopt a generic, declarative maintenance-policy system derived from the
+`arch-strix-halo-pkgs` approach, then express the `codex-app` ingestion policy
+as the first instance. The current `tools/ingest_codex_app.zsh` helper should be
+treated as a working bridge, not the final package-policy architecture.
+
+Deliverables:
+
+- A small policy format for package maintenance rules, including source
+  checkout location, freshness window, artifact selection, build command, and
+  ingest/publish behavior.
+- A canonical ignored `upstream/` checkout area for source repos that are not
+  owned by this repo.
+- A runner that can evaluate a package's policy and perform the declared
+  action.
+- A `codex-app` policy that preserves the current rule: use a package built in
+  the past 24 hours when present; otherwise run `make pacman` in
+  `upstream/codex-app-linux`, cloning the source repo first when needed.
+- Maintainer docs that explain how to add another package with the same policy
+  mechanism.
+
+Exit criteria:
+
+- `codex-app` no longer needs a one-off ingest script for its normal update
+  path.
+- A maintainer can add a second package policy without designing new plumbing.
+- The policy runner reports clearly whether it reused a fresh artifact, built a
+  new artifact, or failed before publishing anything.
+
 ### Package `amerge` for shared local-repo management
 
 `amerge` is not part of this repo workflow yet. The current install path is the

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -166,9 +166,10 @@ by the maintained `codex-app-linux` source repo, and this repo should ingest a
 fresh package artifact when one exists instead of rebuilding it here.
 
 Adopt a generic, declarative maintenance-policy system derived from the
-`arch-strix-halo-pkgs` approach, then express the `codex-app` ingestion policy
-as the first instance. The current `tools/ingest_codex_app.zsh` helper should be
-treated as a working bridge, not the final package-policy architecture.
+[`arch-strix-halo-pkgs`](https://github.com/nisavid/arch-strix-halo-pkgs)
+approach, then express the `codex-app` ingestion policy as the first instance.
+The current `tools/ingest_codex_app.zsh` helper should be treated as a working
+bridge, not the final package-policy architecture.
 
 Deliverables:
 
@@ -199,12 +200,14 @@ Exit criteria:
 explicit build, refresh, publish, and install sequence in
 [`docs/usage/local-repo.md`](usage/local-repo.md).
 
-Future work may extract `amerge` from `arch-strix-halo-pkgs` into its own
-package, then use that shared tool as the local-repo package manager for both
-repos.
+Future work may extract `amerge` from
+[`arch-strix-halo-pkgs`](https://github.com/nisavid/arch-strix-halo-pkgs) into
+its own package, then use that shared tool as the local-repo package manager for
+both repos.
 
 Exit criteria:
 
-- `amerge` is available as a package outside `arch-strix-halo-pkgs`.
+- `amerge` is available as a package outside
+  [`arch-strix-halo-pkgs`](https://github.com/nisavid/arch-strix-halo-pkgs).
 - This repo's local-repo usage docs either adopt it or explicitly keep the
   manual workflow as the preferred path.

--- a/packages/README.md
+++ b/packages/README.md
@@ -8,6 +8,7 @@ notes.
 
 | Directory | Package | Use it when |
 | --- | --- | --- |
+| [`codex-app`](codex-app/) | `codex-app` | You want to ingest the pacman package produced by the maintained Codex App Linux repo. |
 | [`qdrant`](qdrant/) | `qdrant` | You need a local vector database with packaged service defaults. |
 | [`hayhooks`](hayhooks/) | `hayhooks` | You want to serve Haystack pipelines over HTTP from a system-managed service. |
 | [`haystack-ai`](haystack-ai/) | `python-haystack-ai` | You need the Haystack Python framework installed from pacman. |

--- a/packages/README.md
+++ b/packages/README.md
@@ -8,7 +8,7 @@ notes.
 
 | Directory | Package | Use it when |
 | --- | --- | --- |
-| [`codex-app`](codex-app/) | `codex-app` | You want to ingest the pacman package produced by the maintained Codex App Linux repo. |
+| [`codex-app`](codex-app/) | `codex-app` | You want the unofficial Linux build of OpenAI Codex's desktop app packaged for pacman. |
 | [`qdrant`](qdrant/) | `qdrant` | You need a local vector database with packaged service defaults. |
 | [`hayhooks`](hayhooks/) | `hayhooks` | You want to serve Haystack pipelines over HTTP from a system-managed service. |
 | [`haystack-ai`](haystack-ai/) | `python-haystack-ai` | You need the Haystack Python framework installed from pacman. |

--- a/packages/codex-app/README.md
+++ b/packages/codex-app/README.md
@@ -1,9 +1,14 @@
 # codex-app
 
-`codex-app` is maintained in
-[`../codex-app-linux`](../../../codex-app-linux/). This repo does not rebuild it
-through a second `PKGBUILD`; it ingests the pacman package produced by that
-source repo.
+`codex-app` packages
+[Codex App for Linux](https://github.com/nisavid/codex-app-linux), an unofficial
+Linux adaptation of the OpenAI Codex desktop app. The source repo converts the
+upstream macOS `Codex.dmg` into a Linux Electron app and builds native package
+artifacts.
+
+This repo does not rebuild `codex-app` through a second `PKGBUILD`; it ingests
+the pacman package produced by
+[nisavid/codex-app-linux](https://github.com/nisavid/codex-app-linux).
 
 Use:
 
@@ -22,9 +27,10 @@ The ingestion policy is:
    the past 24 hours, run `make pacman` in that repo, then ingest the newest
    package it produced.
 3. If `upstream/codex-app-linux` is absent, clone
-   `https://github.com/nisavid/codex-app-linux.git` there, run `make pacman`,
-   then ingest the newest package it produced.
+   [nisavid/codex-app-linux](https://github.com/nisavid/codex-app-linux) there,
+   run `make pacman`, then ingest the newest package it produced.
 
-For this workspace, `upstream/codex-app-linux` is a local symlink to the sibling
-`../codex-app-linux` checkout. The contents of `upstream/` are ignored so source
-checkouts and symlinks stay local.
+For this workspace, `upstream/codex-app-linux` may be a local symlink to a
+checkout of [nisavid/codex-app-linux](https://github.com/nisavid/codex-app-linux).
+The contents of `upstream/` are ignored so source checkouts and symlinks stay
+local.

--- a/packages/codex-app/README.md
+++ b/packages/codex-app/README.md
@@ -1,0 +1,30 @@
+# codex-app
+
+`codex-app` is maintained in
+[`../codex-app-linux`](../../../codex-app-linux/). This repo does not rebuild it
+through a second `PKGBUILD`; it ingests the pacman package produced by that
+source repo.
+
+Use:
+
+```bash
+tools/ingest_codex_app.zsh
+```
+
+## Update Policy
+
+The ingestion policy is:
+
+1. If `upstream/codex-app-linux` is present and its `dist/` directory
+   contains a `codex-app-*.pkg.tar.*` package built in the past 24 hours, ingest
+   that package.
+2. If `upstream/codex-app-linux` is present but has no package built in
+   the past 24 hours, run `make pacman` in that repo, then ingest the newest
+   package it produced.
+3. If `upstream/codex-app-linux` is absent, clone
+   `https://github.com/nisavid/codex-app-linux.git` there, run `make pacman`,
+   then ingest the newest package it produced.
+
+For this workspace, `upstream/codex-app-linux` is a local symlink to the sibling
+`../codex-app-linux` checkout. The contents of `upstream/` are ignored so source
+checkouts and symlinks stay local.

--- a/tools/ingest_codex_app.zsh
+++ b/tools/ingest_codex_app.zsh
@@ -11,6 +11,7 @@ repo_dir=${repo_root}/repo/x86_64
 repo_name=nisavid
 upstream_url=https://github.com/nisavid/codex-app-linux.git
 max_age_hours=24
+cloned_source=0
 
 usage() {
   cat <<EOF
@@ -36,7 +37,7 @@ need_command() {
 
 latest_package() {
   emulate -L zsh
-  setopt pipe_fail
+  setopt errexit nounset pipefail
 
   local dist_dir=$1
   local max_minutes=${2:-0}
@@ -44,25 +45,31 @@ latest_package() {
 
   [[ -d "$dist_dir" ]] || return 1
 
-  find_cmd=(find "$dist_dir" -maxdepth 1 -type f -name 'codex-app-*.pkg.tar.*')
+  find_cmd=(
+    find "$dist_dir" -maxdepth 1 -type f
+    '(' -name 'codex-app-*.pkg.tar.zst' -o -name 'codex-app-*.pkg.tar.xz' ')'
+  )
   if (( max_minutes > 0 )); then
     find_cmd+=(-mmin "-${max_minutes}")
   fi
+  find_cmd+=(-printf '%T@ %p\n')
 
-  "${find_cmd[@]}" -printf '%T@ %p\n' \
+  "${find_cmd[@]}" \
     | sort -nr \
     | sed -n '1{s/^[^ ]* //;p;}'
 }
 
 ensure_source_dir() {
   if [[ -e "$source_dir" ]]; then
-    [[ -d "$source_dir/.git" ]] || die "source dir is not a git checkout: $source_dir"
+    git -C "$source_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+      || die "source dir is not a git checkout: $source_dir"
     return
   fi
 
   mkdir -p -- "${source_dir:h}"
   print -ru2 -- "Cloning codex-app-linux into $source_dir"
   git clone "$upstream_url" "$source_dir"
+  cloned_source=1
 }
 
 build_package() {
@@ -139,10 +146,15 @@ main() {
   ensure_source_dir
 
   local package_path
-  package_path=$(latest_package "${source_dir}/dist" $(( max_age_hours * 60 )) || true)
-  if [[ -z "$package_path" ]]; then
+  if (( cloned_source )); then
     build_package
     package_path=$(latest_package "${source_dir}/dist" 0 || true)
+  else
+    package_path=$(latest_package "${source_dir}/dist" $(( max_age_hours * 60 )) || true)
+    if [[ -z "$package_path" ]]; then
+      build_package
+      package_path=$(latest_package "${source_dir}/dist" 0 || true)
+    fi
   fi
 
   [[ -n "$package_path" ]] || die "no codex-app package found in ${source_dir}/dist"

--- a/tools/ingest_codex_app.zsh
+++ b/tools/ingest_codex_app.zsh
@@ -1,0 +1,152 @@
+#!/usr/bin/env zsh
+
+emulate -L zsh
+setopt errexit nounset pipefail
+
+script_dir=${0:A:h}
+script_name=${0:t}
+repo_root=${script_dir:h}
+source_dir=${CODEX_APP_LINUX_DIR:-${repo_root}/upstream/codex-app-linux}
+repo_dir=${repo_root}/repo/x86_64
+repo_name=nisavid
+upstream_url=https://github.com/nisavid/codex-app-linux.git
+max_age_hours=24
+
+usage() {
+  cat <<EOF
+Usage: ${script_name} [--source-dir DIR] [--repo-dir DIR] [--repo-name NAME]
+
+Ingest the codex-app pacman package built by codex-app-linux.
+
+Policy:
+  - Use a codex-app package from source-dir/dist if it is newer than 24 hours.
+  - Otherwise run 'make pacman' in source-dir, then ingest the newest package.
+  - If source-dir is missing, clone ${upstream_url} first.
+EOF
+}
+
+die() {
+  print -ru2 -- "$*"
+  exit 2
+}
+
+need_command() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+latest_package() {
+  emulate -L zsh
+  setopt pipe_fail
+
+  local dist_dir=$1
+  local max_minutes=${2:-0}
+  local -a find_cmd
+
+  [[ -d "$dist_dir" ]] || return 1
+
+  find_cmd=(find "$dist_dir" -maxdepth 1 -type f -name 'codex-app-*.pkg.tar.*')
+  if (( max_minutes > 0 )); then
+    find_cmd+=(-mmin "-${max_minutes}")
+  fi
+
+  "${find_cmd[@]}" -printf '%T@ %p\n' \
+    | sort -nr \
+    | sed -n '1{s/^[^ ]* //;p;}'
+}
+
+ensure_source_dir() {
+  if [[ -e "$source_dir" ]]; then
+    [[ -d "$source_dir/.git" ]] || die "source dir is not a git checkout: $source_dir"
+    return
+  fi
+
+  mkdir -p -- "${source_dir:h}"
+  print -ru2 -- "Cloning codex-app-linux into $source_dir"
+  git clone "$upstream_url" "$source_dir"
+}
+
+build_package() {
+  print -ru2 -- "No codex-app package newer than ${max_age_hours}h; running make pacman"
+  (cd -- "$source_dir" && make pacman)
+}
+
+stage_package() {
+  local package_path=$1
+  local repo_db=${repo_dir}/${repo_name}.db.tar.zst
+  local staged_path=${repo_dir}/${package_path:t}
+  local package_name
+
+  mkdir -p -- "$repo_dir"
+
+  package_name=$(pacman -Qp -- "$package_path" | awk '{print $1}')
+  [[ "$package_name" == codex-app ]] || die "expected codex-app package, got: $package_name"
+
+  if [[ -e "$repo_db" ]]; then
+    repo-remove "$repo_db" codex-app >/dev/null 2>&1 || true
+  fi
+
+  local existing_archive existing_meta existing_name
+  for existing_archive in "$repo_dir"/*.pkg.tar.*(N); do
+    existing_meta=$(pacman -Qp -- "$existing_archive" 2>/dev/null) || continue
+    existing_name=${existing_meta%% *}
+    if [[ "$existing_name" == codex-app ]]; then
+      rm -f -- "$existing_archive"
+    fi
+  done
+
+  rm -f -- "$staged_path"
+  ln -- "$package_path" "$staged_path" 2>/dev/null || cp -f -- "$package_path" "$staged_path"
+  repo-add "$repo_db" "$staged_path" >/dev/null
+
+  print -- "Updated pacman repo: $repo_db"
+  print -- "Staged package: ${staged_path:t}"
+}
+
+main() {
+  while (( $# )); do
+    case "$1" in
+      --source-dir)
+        (( $# >= 2 )) || die "--source-dir requires a value"
+        source_dir=${2:A}
+        shift 2
+        ;;
+      --repo-dir)
+        (( $# >= 2 )) || die "--repo-dir requires a value"
+        repo_dir=${2:A}
+        shift 2
+        ;;
+      --repo-name)
+        (( $# >= 2 )) || die "--repo-name requires a value"
+        repo_name=$2
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        return 0
+        ;;
+      *)
+        die "unknown argument: $1"
+        ;;
+    esac
+  done
+
+  need_command git
+  need_command make
+  need_command pacman
+  need_command repo-add
+  need_command repo-remove
+
+  ensure_source_dir
+
+  local package_path
+  package_path=$(latest_package "${source_dir}/dist" $(( max_age_hours * 60 )) || true)
+  if [[ -z "$package_path" ]]; then
+    build_package
+    package_path=$(latest_package "${source_dir}/dist" 0 || true)
+  fi
+
+  [[ -n "$package_path" ]] || die "no codex-app package found in ${source_dir}/dist"
+  stage_package "$package_path"
+}
+
+main "$@"

--- a/upstream/.gitignore
+++ b/upstream/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary

- Add a codex-app ingestion helper that consumes pacman packages from the maintained codex-app-linux checkout.
- Document the 24-hour reuse-or-build update policy for codex-app.
- Add an ignored upstream checkout area and list codex-app first in the package catalog.

## Validation

- zsh -n tools/ingest_codex_app.zsh
- tools/ingest_codex_app.zsh
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the `codex-app` package, including ingestion policy and update procedures
  * Updated workflow planning with new declarative package-maintenance system

* **Chores**
  * Added package ingestion automation tool for streamlined artifact management
  * Added upstream directory configuration to maintain local checkout integrity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->