### PR TITLE
[codex] streamline package docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,24 +5,28 @@ Personal Arch Linux packages for a local AI application stack.
 This repository collects packages that are useful enough to keep close, patched,
 and installable through a local pacman repository. It is not a public distro or a
 general AUR mirror. It is a small workspace for reproducible local packages:
-vector storage, Haystack services, their Python dependencies, and an
-experimental GPU inspection tool.
+Codex desktop app packaging, vector storage, Haystack services, their Python
+dependencies, and an experimental GPU inspection tool.
 
 ## What You Can Install
 
-| Package | Packaged version | Why it is here |
-| --- | ---: | --- |
-| [`qdrant`](packages/qdrant/) | `1.17.1-1` | Vector database with local-only defaults and a packaged `systemd` service. |
-| [`hayhooks`](packages/hayhooks/) | `1.17.0-1` | Haystack pipeline server with a local service account, env file, and pipeline directory. |
-| [`electron41`](packages/electron41/) | `41.3.0-1` | Source-built Electron 41 runtime for packages that need this major line. |
-| [`utilyze`](packages/utilyze/) | `0.1.1-2` | Experimental NVIDIA GPU utilization TUI with Arch runtime, config, update, and telemetry-consent patches. |
-| [`python-haystack-ai`](packages/haystack-ai/) | `2.28.0-1` | Haystack framework package used by `hayhooks` and local pipeline work. |
-| [`python-haystack-experimental`](packages/python-haystack-experimental/) | `0.19.0-1` | Experimental Haystack components. |
-| [`python-fastapi-openai-compat`](packages/python-fastapi-openai-compat/) | `1.2.0-1` | OpenAI-compatible FastAPI router dependency. |
-| [`python-posthog`](packages/python-posthog/) | `7.13.0-1` | Python PostHog client dependency. |
-| [`python-docstring-parser`](packages/python-docstring-parser/) | `0.18.0-1` | Python docstring parser dependency. |
-| [`python-lazy-imports`](packages/python-lazy-imports/) | `1.2.0-1` | Lazy import helper dependency. |
-| [`python-backoff`](packages/python-backoff/) | `2.2.1-1` | Retry/backoff helper dependency. |
+The full package catalog lives in [`packages/README.md`](packages/README.md).
+Use it when you need all packages, package names, categories, and package-local
+notes.
+
+Start with the package family that matches what you want to install:
+
+- [`codex-app`](packages/codex-app/) packages the unofficial Linux build of
+  OpenAI Codex's desktop app for pacman.
+- [`qdrant`](packages/qdrant/) and [`hayhooks`](packages/hayhooks/) provide the
+  local service layer for vector storage and Haystack pipeline serving.
+- [`python-haystack-ai`](packages/haystack-ai/) and its companion Python
+  packages support local Haystack work where the desired versions are not
+  available in the right shape.
+- [`electron41`](packages/electron41/) provides a source-built Electron runtime
+  for packages that need that major line.
+- [`utilyze`](packages/utilyze/) is an experimental NVIDIA GPU utilization TUI
+  with Arch runtime, config, update, and telemetry-consent patches.
 
 > [!NOTE]
 > `utilyze` is packaged and partially verified, but it still needs runtime

--- a/packages/codex-app/README.md
+++ b/packages/codex-app/README.md
@@ -35,15 +35,15 @@ sudo pacman -S codex-app
 
 The ingestion policy is:
 
-1. If `upstream/codex-app-linux` is present and its `dist/` directory
-   contains a `codex-app-*.pkg.tar.*` package built in the past 24 hours, ingest
-   that package.
+1. If `upstream/codex-app-linux` is present and its `dist/` directory contains
+   a `codex-app-*.pkg.tar.zst` or `codex-app-*.pkg.tar.xz` package modified in
+   the past 24 hours, ingest the newest matching file by filesystem mtime.
 2. If `upstream/codex-app-linux` is present but has no package built in
-   the past 24 hours, run `make pacman` in that repo, then ingest the newest
-   package it produced.
+   the past 24 hours, run `make pacman` in `upstream/codex-app-linux`, then
+   ingest the newest matching package in `dist/` by filesystem mtime.
 3. If `upstream/codex-app-linux` is absent, clone
    [nisavid/codex-app-linux](https://github.com/nisavid/codex-app-linux) there,
-   run `make pacman`, then ingest the newest package it produced.
+   run `make pacman`, then ingest the newest matching package in `dist/`.
 
 For this workspace, `upstream/codex-app-linux` may be a local symlink to a
 checkout of [nisavid/codex-app-linux](https://github.com/nisavid/codex-app-linux).

--- a/packages/codex-app/README.md
+++ b/packages/codex-app/README.md
@@ -1,19 +1,34 @@
 # codex-app
 
-`codex-app` packages
+`codex-app` is the pacman package for
 [Codex App for Linux](https://github.com/nisavid/codex-app-linux), an unofficial
-Linux adaptation of the OpenAI Codex desktop app. The source repo converts the
-upstream macOS `Codex.dmg` into a Linux Electron app and builds native package
-artifacts.
+Linux adaptation of the OpenAI Codex desktop app.
+
+Use this package when you want the Codex desktop app installed and upgraded
+through the local `nisavid` pacman repo.
+
+## How This Package Is Produced
 
 This repo does not rebuild `codex-app` through a second `PKGBUILD`; it ingests
 the pacman package produced by
-[nisavid/codex-app-linux](https://github.com/nisavid/codex-app-linux).
+[nisavid/codex-app-linux](https://github.com/nisavid/codex-app-linux). That
+source repo converts the upstream macOS `Codex.dmg` into a Linux Electron app
+and builds native package artifacts.
 
-Use:
+Run the ingest helper from this repo's root:
 
 ```bash
 tools/ingest_codex_app.zsh
+```
+
+The helper stages the package in `repo/x86_64/`. Publish the local repo and
+install `codex-app` with pacman using the workflow in
+[`docs/usage/local-repo.md`](../../docs/usage/local-repo.md).
+
+After the local repo is published and enabled:
+
+```bash
+sudo pacman -S codex-app
 ```
 
 ## Update Policy


### PR DESCRIPTION
## Summary

- Replace the top-level README package version table with a shorter package-family overview.
- Route the full package inventory to packages/README.md.
- Rework packages/codex-app/README.md to lead with user-facing package and install context while keeping the ingest policy for maintainers.

## Validation

- git diff --check HEAD~1..HEAD
- checked local link targets referenced by the changed docs
- searched for stale version-table wording and removed catalog-boundary leftovers

## Review

Ralph Review Cycle 1 completed with no findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * README reorganized to use a package catalog and now highlights desktop app packaging alongside existing components.
  * Top-level docs link to per-package catalogs for complete package lists.
  * codex-app docs updated with explicit install steps via a local pacman repository and a clarified update policy that restricts accepted package formats and selects the newest matching artifact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->