### PR TITLE
docs(readme): document codex app ingest flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,11 @@ If you want one package quickly, build and install it from its package directory
 ```
 
 `codex-app` is different from the normal `PKGBUILD` packages: this repo ingests
-the pacman package produced by the maintained `codex-app-linux` checkout. To
-refresh and stage the latest Codex desktop app package:
+the pacman package produced by the maintained `codex-app-linux` source repo. The
+ingest helper uses `upstream/codex-app-linux` by default, clones that checkout
+when it is missing, and accepts `CODEX_APP_LINUX_DIR` when you want to point at
+another local checkout. To refresh and stage the latest Codex desktop app
+package:
 
 ```bash
 tools/ingest_codex_app.zsh

--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ If you want one package quickly, build and install it from its package directory
 (cd packages/qdrant && makepkg --verifysource && makepkg -si)
 ```
 
+`codex-app` is different from the normal `PKGBUILD` packages: this repo ingests
+the pacman package produced by the maintained `codex-app-linux` checkout. To
+refresh and stage the latest Codex desktop app package:
+
+```bash
+tools/ingest_codex_app.zsh
+tools/publish_pacman_repo.zsh
+sudo pacman -Sy
+sudo pacman -S codex-app
+```
+
 If you want the normal workflow, build a package, refresh the local repo staging
 area, publish it to a pacman-visible path, and install through pacman:
 


### PR DESCRIPTION
## Summary
- update the root README with the codex-app ingest/publish/install path
- make clear codex-app differs from normal package-directory PKGBUILD installs

## Verification
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * README updated with a dedicated workflow for the codex-app packages, describing how to ingest external package output, publish it to the package repository, refresh package metadata, and install codex-app using the documented command sequence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->