### PR TITLE
docs(skills/packaging): require repo-level update docs review

### DIFF
--- a/.agents/skills/maintaining-arch-packages/SKILL.md
+++ b/.agents/skills/maintaining-arch-packages/SKILL.md
@@ -49,10 +49,11 @@ before implementing the local package:
 - Treat an update request as including package-local README or maintainer-doc
   updates when the update changes package behavior, source provenance, build
   commands, install commands, service behavior, or known validation boundaries.
-- Treat an update request as including root README and package-catalog review
-  when the update changes the visible package list, package selection guidance,
-  install path, update path, local-repo workflow, or another user-facing
-  workflow described at repository scope.
+- Treat an update request as including repo-level user-doc updates when the
+  update changes the visible package list, package selection guidance, install
+  path, update path, local-repo workflow, or another user-facing workflow
+  described at repository scope. Check `README.md` and `packages/README.md`,
+  and update any stale repository-scope guidance before closeout.
 - Unless the user explicitly asks for a local-only update, continue through the
   repository's normal branch, commit, pull request, and merge flow after local
   verification passes.

--- a/.agents/skills/maintaining-arch-packages/SKILL.md
+++ b/.agents/skills/maintaining-arch-packages/SKILL.md
@@ -49,6 +49,10 @@ before implementing the local package:
 - Treat an update request as including package-local README or maintainer-doc
   updates when the update changes package behavior, source provenance, build
   commands, install commands, service behavior, or known validation boundaries.
+- Treat an update request as including root README and package-catalog review
+  when the update changes the visible package list, package selection guidance,
+  install path, update path, local-repo workflow, or another user-facing
+  workflow described at repository scope.
 - Unless the user explicitly asks for a local-only update, continue through the
   repository's normal branch, commit, pull request, and merge flow after local
   verification passes.


### PR DESCRIPTION
Summary
- Require package-update closeout to update repo-level user docs when repository-scope package workflows change.
- Name the exact docs that must be checked: `README.md` and `packages/README.md`.

Ralph Review
- Cycle 1: found that the closeout workflow only named package-local README or maintainer docs, leaving root README/package catalog updates implicit.
- Cycle 2: Copilot and Greptile found that the new wording used ambiguous doc names and the weaker verb “review.”
- Cycle 3: clean locally after switching to repo-level user-doc updates and explicit `README.md` / `packages/README.md` guidance.

Verification
- `git diff --check` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified closeout workflow to require review and update of project root and packages documentation when changes affect user-facing package lists, selection guidance, or install/update workflows.
  * Ensures user-facing guidance and package listings remain synchronized as part of request closeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->