### PR TITLE
feat(repo/consistency): enforce refresh safeguards

### DIFF
--- a/.github/workflows/repository-consistency.yml
+++ b/.github/workflows/repository-consistency.yml
@@ -21,7 +21,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          pacman -Syu --noconfirm git jq python python-yaml rsync zsh
+          for attempt in 1 2 3 4; do
+            if pacman -Syyu --noconfirm git jq python python-yaml rsync zsh; then
+              break
+            fi
+            if [[ "${attempt}" == 4 ]]; then
+              exit 1
+            fi
+            sleep "$((attempt * 15))"
+          done
 
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/repository-consistency.yml
+++ b/.github/workflows/repository-consistency.yml
@@ -1,0 +1,48 @@
+name: Repository Consistency
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  consistency:
+    name: Repository consistency
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container:
+      image: archlinux:base-devel
+    steps:
+      - name: Install test dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          pacman -Syu --noconfirm git jq python python-yaml rsync zsh
+
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Verify required test tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          for command in bsdtar git makepkg python3 repo-add repo-remove rsync zsh zstd; do
+            command -v "${command}"
+          done
+          python3 -c 'import yaml'
+
+      - name: Run repository consistency gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          useradd --create-home --shell /bin/bash consistency
+          chown -R consistency:consistency "${GITHUB_WORKSPACE}"
+          runuser -u consistency -- \
+            env HOME=/home/consistency \
+            python3 tools/check_repo_consistency.py

--- a/README.md
+++ b/README.md
@@ -101,8 +101,10 @@ The full local-repo setup, including the pacman stanza, is in
 - **I want to try `utilyze`.** Read
   [`packages/utilyze/README.Arch.md`](packages/utilyze/README.Arch.md), then
   check the active validation work in [`docs/backlog.md`](docs/backlog.md).
-- **I am maintaining the repo.** Read `AGENTS.md` and the repo-local skills in
-  `.agents/skills/`.
+- **I am maintaining the repo.** Read `AGENTS.md`, the checked
+  [`packages/`](packages/) refresh index, and the repo-local skills in
+  `.agents/skills/`. Before review, run
+  `python3 tools/check_repo_consistency.py` from the repository root.
 
 ## Repository Map
 

--- a/docs/policies/reference-packages.md
+++ b/docs/policies/reference-packages.md
@@ -56,19 +56,44 @@ Before writing a new `packages/<name>/PKGBUILD`:
 
 ## Package README Metadata
 
-Every onboarded package should include a maintenance baseline section with:
+Every `accepted-current` or `deferred` package in the checked refresh index must
+have a package README with exactly one nonempty entry for each of these fields:
 
-- `authoritative_reference`
-- `advisory_references`
-- `divergence_notes`
-- `update_notes`
+```markdown
+## Maintenance Baseline
 
-The section should answer:
+- `authoritative_reference`: <the package recipe or upstream source to diff first>
+- `advisory_references`: <nearby packages and upstream material worth scouting>
+- `divergence_notes`: <deliberate local differences, or an explicit statement that there are none>
+- `update_notes`: <the mandatory update and validation checks>
+```
 
-- what package or upstream source to diff first
-- what nearby packages are worth scouting
-- which divergences are deliberate
-- which validation gates are mandatory after an update
+The values may continue on indented lines when a field needs a list. Use `none`
+only when review established that there is no relevant advisory reference or no
+deliberate divergence; do not leave a value blank. A retired package is exempt
+because its disposition and preservation-aware removal boundary live in the
+refresh index and decision record rather than a maintained baseline.
+
+The four fields answer different questions:
+
+- `authoritative_reference` identifies the first package or upstream source to
+  compare and its compatibility lane.
+- `advisory_references` identifies other useful packaging, service, dependency,
+  or platform sources without treating them as authoritative.
+- `divergence_notes` states the local source, dependency, integration, privacy,
+  or service behavior that an update must preserve or deliberately replace.
+- `update_notes` states the freshness checks and lane-specific build, payload,
+  migration, runtime, privacy, or hardware gates required after an update.
+
+The repository consistency checker enforces field presence and basic shape:
+
+```bash
+python3 tools/check_repo_consistency.py
+```
+
+It does not decide whether the selected reference, divergence, or acceptance
+gate is correct. That remains human package review; this policy is not a
+generalized package-policy engine.
 
 ## Guardrails
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -5,39 +5,63 @@ lanes carry a `PKGBUILD`, `.SRCINFO`, service assets, patches, and local notes.
 The `chatgpt` lane is the explicit exception: it accepts an exact package
 artifact and provenance record, so it has no local `PKGBUILD` or `.SRCINFO`.
 
-## Inventory
+## Refresh Index
 
-Package freshness is checked per maintenance task. The ChatGPT artifact lane
-was last reviewed on 2026-08-16; the remaining catalog was last swept on
-2026-05-23.
+This is the checked human record for the current repository refresh. It was
+reconciled on 2026-08-17 against the complete dated upstream sweep and the
+subsequent package-lane decisions. The packaged version is mechanical truth
+from `.SRCINFO`, except for the immutable `chatgpt` lane, where the tracked
+artifact baseline is authoritative. A review date records the latest human
+target or disposition review; it is not an assertion that no newer release
+exists.
 
-| Directory | Package | Packaged version | Upstream status | Use it when |
-| --- | --- | --- | --- | --- |
-| [`chatgpt`](chatgpt/) | `chatgpt` | 26.810.52044-1 | Accepted exact artifact from `fallback-baseline-2026-08-16` | You want the maintained ChatGPT for Linux fallback installed through pacman. |
-| [`open-webui`](open-webui/) | `open-webui` | 0.9.5-1 | Current | You want Open WebUI managed by pacman and `systemd` with local-only service defaults. |
-| [`ctranslate2`](ctranslate2/) | `ctranslate2`, `python-ctranslate2` | 4.7.2-1 | Current | You need a generic CPU/OpenBLAS CTranslate2 provider for Python applications. |
-| [`qdrant`](qdrant/) | `qdrant` | 1.18.1-2 | Current | You need a local vector database with packaged service defaults. |
-| [`hayhooks`](hayhooks/) | `hayhooks` | 1.19.1-1 | Current | You want to serve Haystack pipelines over HTTP from a system-managed service. |
-| [`haystack-ai`](haystack-ai/) | `python-haystack-ai` | 2.29.0-1 | Current | You need the Haystack Python framework installed from pacman. |
-| [`thorium-browser-updated`](thorium-browser-updated/) | `thorium-browser-updated` | 149.0.7827.114-4 | Metadata-only ingest | You want Thorium Browser built from source using the fixed tarball/tag recipe. |
-| [`utilyze`](utilyze/) | `utilyze` | 0.1.1-2 | 0.1.3 available; focused patch-refresh lane | You want to inspect NVIDIA GPU utilization with the experimental Arch-patched TUI. |
+The dispositions have deliberately narrow meanings:
 
-## Supporting Python Packages
+- `accepted-current`: the selected package or artifact passed its lane-specific
+  acceptance gate and may enter the terminal publication manifest.
+- `deferred`: the named target is still maintained, but the row states its next
+  gate and whether any package from that lane may be published in this refresh.
+- `retired`: the package is excluded from the final inventory and scheduled for
+  preservation-aware source and artifact cleanup.
 
-These packages exist because the primary stack depends on versions that are not
-available locally in the desired shape:
+Publication eligibility refers to the terminal clean refresh manifest, not to
+whether an old archive exists or a recipe can be built. Every deferred lane in
+this refresh is excluded until a later acceptance record explicitly promotes
+it. The empty legacy `packages/codex-app/` directory is not a package lane: it
+has no recipe or immutable artifact baseline and therefore has no catalog row.
 
-| Directory | Package | Packaged version | Upstream status |
-| --- | --- | --- | --- |
-| [`python-backoff`](python-backoff/) | `python-backoff` | 2.2.1-1 | Current |
-| [`python-docstring-parser`](python-docstring-parser/) | `python-docstring-parser` | 0.18.0-1 | Current |
-| [`python-fastapi-openai-compat`](python-fastapi-openai-compat/) | `python-fastapi-openai-compat` | 1.2.0-1 | Current |
-| [`python-haystack-experimental`](python-haystack-experimental/) | `python-haystack-experimental` | 0.19.0-1 | Current |
-| [`python-lazy-imports`](python-lazy-imports/) | `python-lazy-imports` | 1.2.0-1 | Current |
-| [`python-posthog`](python-posthog/) | `python-posthog` | 7.15.3-1 | Current |
-| [`python-faster-whisper`](python-faster-whisper/) | `python-faster-whisper` | 1.2.1-1 | Current |
-| [`python-rapidocr-onnxruntime`](python-rapidocr-onnxruntime/) | `python-rapidocr-onnxruntime` | 1.4.4-1 | Current |
-| [`python-sentence-transformers`](python-sentence-transformers/) | `python-sentence-transformers` | 5.5.1-1 | Current |
+| Directory | Package | Packaged version | Disposition | Reviewed target or cursor | Review date | Acceptance state or next gate | Publication eligible |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| [`chatgpt`](chatgpt/) | `chatgpt` | 26.810.52044-1 | accepted-current | [`fallback-baseline-2026-08-16`](https://github.com/nisavid/chatgpt-linux/tree/fallback-baseline-2026-08-16) at `dd3d1397f544752ea1170af8393cd59379373f52` | 2026-08-17 | Exact ingest, repository publication, fallback installation, and host acceptance passed; retain the fallback only until the separate parity and sunsetting decision releases it. | yes |
+| [`ctranslate2`](ctranslate2/) | `ctranslate2`, `python-ctranslate2` | 4.7.2-1 | deferred | [CTranslate2 4.8.1](https://github.com/nisavid/arch-pkgs/issues/26#issuecomment-5258698835) | 2026-08-11 | Excluded; pass the Open WebUI speech G0-G2 package, payload, offline-runtime, and Faster Whisper checks. | no |
+| [`hayhooks`](hayhooks/) | `hayhooks` | 1.19.2-1 | deferred | [Hayhooks 1.23.0](https://github.com/nisavid/arch-pkgs/issues/27#issuecomment-5259162959) | 2026-08-11 | Excluded; pass the Haystack 3 package gates, Qdrant-backed G4 service gate, v2-to-v3 migration, and rollback drill. | no |
+| [`haystack-ai`](haystack-ai/) | `python-haystack-ai` | 2.29.0-1 | deferred | [Haystack 3.0.0](https://github.com/nisavid/arch-pkgs/issues/27#issuecomment-5259162959) | 2026-08-11 | Excluded; pass the Haystack 3 package gates, Qdrant-backed G4 service gate, v2-to-v3 migration, and rollback drill. | no |
+| [`open-webui`](open-webui/) | `open-webui` | 0.9.5-1 | deferred | [Open WebUI 0.11.0](https://github.com/nisavid/arch-pkgs/issues/26#issuecomment-5258698835) | 2026-08-11 | Excluded; pass Python 3.14 and system-ML G0-G2, then household HTTPS, migration, browser, preservation, and whole-runtime rollback G3-G4. | no |
+| [`python-backoff`](python-backoff/) | `python-backoff` | 2.2.1-1 | deferred | [backoff 2.2.1; review AUR packaging revision 2.2.1-4](https://github.com/nisavid/arch-pkgs/issues/27#issuecomment-5259162959) | 2026-08-11 | Excluded; accept as part of the complete Haystack 3 dependency closure and composed service gate. | no |
+| [`python-docstring-parser`](python-docstring-parser/) | `python-docstring-parser` | 0.18.0-1 | deferred | [docstring-parser 0.18.0](https://github.com/nisavid/arch-pkgs/issues/27#issuecomment-5259162959) | 2026-08-11 | Excluded; accept as part of the complete Haystack 3 dependency closure and composed service gate. | no |
+| [`python-fastapi-openai-compat`](python-fastapi-openai-compat/) | `python-fastapi-openai-compat` | 1.2.0-1 | deferred | [fastapi-openai-compat 1.2.0](https://github.com/nisavid/arch-pkgs/issues/27#issuecomment-5259162959) | 2026-08-11 | Excluded; pass the Hayhooks 1.23 and Haystack 3 compatibility and composed service gates. | no |
+| [`python-faster-whisper`](python-faster-whisper/) | `python-faster-whisper` | 1.2.1-1 | deferred | [Faster Whisper 1.2.1](https://github.com/nisavid/arch-pkgs/issues/26#issuecomment-5258698835) | 2026-08-11 | Excluded; pass the Open WebUI speech G0-G2 gate with CTranslate2 4.8.1. | no |
+| [`python-haystack-experimental`](python-haystack-experimental/) | `python-haystack-experimental` | 0.19.0-1 | retired | [Retire after final archived 0.19.0.post1](https://github.com/nisavid/arch-pkgs/issues/27#issuecomment-5259162959) | 2026-08-11 | Retired from the Haystack 3 dependency set; preserve the rollback artifact until migration acceptance releases it, then remove source and artifacts. | no |
+| [`python-lazy-imports`](python-lazy-imports/) | `python-lazy-imports` | 1.2.0-1 | deferred | [lazy-imports 1.2.0](https://github.com/nisavid/arch-pkgs/issues/27#issuecomment-5259162959) | 2026-08-11 | Excluded; accept as part of the complete Haystack 3 dependency closure and composed service gate. | no |
+| [`python-posthog`](python-posthog/) | `python-posthog` | 7.16.2-1 | deferred | [PostHog 7.38.4](https://github.com/nisavid/arch-pkgs/issues/27#issuecomment-5259162959) | 2026-08-11 | Excluded; pass dependency, no-network, and telemetry-disabled privacy acceptance with the Haystack 3 lane. | no |
+| [`python-rapidocr-onnxruntime`](python-rapidocr-onnxruntime/) | `python-rapidocr-onnxruntime` | 1.4.4-1 | retired | [Retire legacy 1.4.4; replace with RapidOCR 3.9.2](https://github.com/nisavid/arch-pkgs/issues/26#issuecomment-5258698835) | 2026-08-11 | Retired; the source-built `python-rapidocr` successor must pass the Open WebUI core gate before preservation-aware cleanup. | no |
+| [`python-sentence-transformers`](python-sentence-transformers/) | `python-sentence-transformers` | 5.5.1-1 | deferred | [Sentence Transformers 5.5.1 for the first accepted Open WebUI set](https://github.com/nisavid/arch-pkgs/issues/26#issuecomment-5258698835) | 2026-08-11 | Excluded; pass the exact Python 3.14 and system-ML provider-set checks and the composed Open WebUI gate. | no |
+| [`qdrant`](qdrant/) | `qdrant` | 1.18.1-2 | deferred | [Qdrant 1.19.0 via 1.18.3, with Qdrant Web UI 0.2.16](https://github.com/nisavid/arch-pkgs/issues/28#issuecomment-5259788912) | 2026-08-11 | Excluded; pass empty-state and 1.17.1-to-1.18.3-to-1.19.0 G0-G3 migration and recovery, then the coupled Haystack G4 gate. | no |
+| [`thorium-browser-updated`](thorium-browser-updated/) | `thorium-browser-updated` | 149.0.7827.114-4 | deferred | [Source-built Alacrium M151.0.7922.108 successor cursor](https://github.com/nisavid/arch-pkgs/issues/29#issuecomment-5261359711) | 2026-08-12 | Excluded; freeze the newest eligible Alacrium release and pass immutable offline two-build reproducibility plus desktop and security G0-G4 before retiring Thorium. | no |
+| [`utilyze`](utilyze/) | `utilyze` | 0.1.1-2 | deferred | [utilyze v0.1.3 at `a9e211813f6717b63ad826e1eb4097cdaea1dd43`](https://github.com/nisavid/arch-pkgs/issues/25#issuecomment-5257258123) | 2026-08-11 | Excluded; pass local package and fail-closed privacy gates, then separately authorize and pass the paid Ampere-or-newer NVIDIA G4 run. | no |
+
+Run the local structural check after editing the catalog or any retained
+package baseline:
+
+```bash
+python3 tools/check_repo_consistency.py
+```
+
+The checker verifies catalog coverage, row shape, package identity and version,
+required baseline-field shape, `.SRCINFO` agreement, tracked Zsh syntax, pinned
+workflow actions, and the committed unit tests. It does not query providers,
+select candidates, build packages, or decide whether lane-specific acceptance
+evidence is sufficient; those remain explicit maintainer review.
 
 ## Build And Publish
 

--- a/packages/chatgpt/README.md
+++ b/packages/chatgpt/README.md
@@ -10,7 +10,7 @@ The accepted fallback is `chatgpt 26.810.52044-1` from annotated tag
 Its public, path-free provenance tuple is recorded in
 [`fallback-baseline-2026-08-16.json`](fallback-baseline-2026-08-16.json).
 
-## Maintenance baseline
+## Maintenance Baseline
 
 - `authoritative_reference`: the exact tagged package output and provenance
   tooling in [`nisavid/chatgpt-linux`](https://github.com/nisavid/chatgpt-linux/tree/dd3d1397f544752ea1170af8393cd59379373f52).

--- a/packages/ctranslate2/README.md
+++ b/packages/ctranslate2/README.md
@@ -13,22 +13,32 @@ application-private tree.
 
 ## Maintenance Baseline
 
-- `authoritative_reference`: `aur/ctranslate2`
-- `advisory_references`: upstream `OpenNMT/CTranslate2` release notes and build
-  documentation
+- `authoritative_reference`: upstream `OpenNMT/CTranslate2` release `v4.8.1`,
+  the selected Open WebUI speech target
+- `advisory_references`: AUR `ctranslate2` split-package recipe and upstream
+  CTranslate2 release notes and build documentation
 - `divergence_notes`:
-  - This package keeps the AUR split-package shape.
-  - This package builds the generic CPU/OpenBLAS lane only.
-  - This package removes the unused Intel oneAPI MKL build dependency from the
-    AUR baseline because `WITH_MKL=OFF`.
-  - ROCm/HIP acceleration is intentionally out of scope here and belongs in the
-    sibling `arch-strix-halo-pkgs` repo if needed.
+  - The current split recipe packages `4.7.2-1`; the selected target is `4.8.1`
+    for its model-load heap-overflow and Whisper correctness fixes.
+  - Preserve the generic CPU/OpenBLAS split-package lane and omit the unused
+    Intel oneAPI MKL dependency while `WITH_MKL=OFF`. ROCm/HIP acceleration
+    remains outside this repository's lane.
+  - For `4.8.1`, map the Thrust source to NVIDIA CCCL, remove the obsolete
+    separate Cub source and setup, retain the required GCC 15 `cxxopts` fix,
+    add `python-setuptools` as a runtime dependency of `python-ctranslate2`, and
+    keep PyTorch optional for conversion rather than required for inference.
 - `update_notes`:
-  - Diff `aur/ctranslate2` before changing the source, submodule, or build
-    options.
-  - Recheck upstream CTranslate2 build options before enabling a new backend.
-  - Keep this package as the generic CPU provider unless a broader package
-    policy says otherwise.
+  - Keep both split packages deferred and excluded from publication until the
+    Open WebUI speech G0-G2 gate passes with Faster Whisper `1.2.1`; version
+    selection alone is not acceptance.
+  - G0 must verify immutable sources, checksums, regenerated `.SRCINFO`, the
+    `4.8.1` source/dependency mapping, patch intent, and the exact speech
+    compatibility matrix.
+  - G1 must clean-build and inspect both package payloads and dependency edges
+    without an undeclared network or runtime acquisition path.
+  - G2 must pass the upstream tests and bundled CPU/OpenBLAS model offline,
+    including malformed-model failure without a crash, then pass the composed
+    Faster Whisper CPU `int8` transcription and word-timestamp fixture.
 
 ## Verification
 

--- a/packages/hayhooks/README.md
+++ b/packages/hayhooks/README.md
@@ -5,6 +5,26 @@ Arch package for the Hayhooks service layer on top of Haystack.
 Use this package when you want to serve Haystack pipelines from a local,
 system-managed HTTP service.
 
+## Maintenance Baseline
+
+- `authoritative_reference`: upstream
+  [`hayhooks` PyPI source and metadata](https://pypi.org/project/hayhooks/1.23.0/);
+  no same-name Arch or AUR recipe was available at the 2026-08 refresh.
+- `advisory_references`: upstream
+  [Hayhooks releases](https://github.com/deepset-ai/hayhooks/releases) and the
+  [Haystack migration guide](https://docs.haystack.deepset.ai/docs/migration).
+- `divergence_notes`: the current recipe packages the `1.19.2` source
+  distribution with a loopback-only, hardened `systemd` service, dedicated
+  service user, and pacman-managed pipeline state. The selected `1.23.0`
+  destination must retain that service shape while disabling production
+  runtime deployment, dashboard builds, and dependency bootstrap; it has not
+  yet been accepted.
+- `update_notes`: verify immutable source identity and the Python 3.14 closure,
+  build cleanly without runtime downloads, inspect the payload, then exercise
+  reviewed YAML and wrapper loading, readiness, REST and OpenAI-compatible
+  behavior, safe deserialization, migration, rollback, and the supported
+  Qdrant-backed composed lane before publication.
+
 ## Package Contents
 
 - `hayhooks` command and Python package files

--- a/packages/haystack-ai/README.md
+++ b/packages/haystack-ai/README.md
@@ -6,6 +6,26 @@ The package name is `python-haystack-ai`. It exists mainly to support
 `hayhooks`, but it is also useful when local Python applications should depend on
 Haystack through pacman instead of a virtual environment.
 
+## Maintenance Baseline
+
+- `authoritative_reference`: upstream
+  [`haystack-ai` PyPI source and metadata](https://pypi.org/project/haystack-ai/3.0.0/);
+  no `python-haystack-ai` Arch or AUR recipe was available at the 2026-08
+  refresh.
+- `advisory_references`: upstream
+  [Haystack releases](https://github.com/deepset-ai/haystack/releases) and the
+  [Haystack migration guide](https://docs.haystack.deepset.ai/docs/migration).
+- `divergence_notes`: the current recipe packages `2.29.0` from its source
+  distribution and still depends on `python-haystack-experimental`. The
+  selected `3.0.0` destination retires that archived dependency and adds the
+  separately packaged Qdrant integration lane; the major-version migration has
+  not yet been accepted.
+- `update_notes`: freeze the selected source and Python 3.14 dependency closure,
+  clean-build and inspect the package without runtime downloads, then prove
+  offline sync and async behavior, serialization, lifecycle, rejected unsafe
+  deserialization, v2-to-v3 pipeline and persisted-ID migration, Qdrant service
+  composition, and a real rollback drill before publication.
+
 ## What It Installs
 
 - Haystack Python framework files

--- a/packages/open-webui/README.md
+++ b/packages/open-webui/README.md
@@ -33,30 +33,53 @@ database settings, and feature flags in `/etc/open-webui/open-webui.env`.
 
 ## Maintenance Baseline
 
-- `authoritative_reference`: `aur/open-webui`
-- `advisory_references`: upstream `open-webui/open-webui` release notes and
-  installation docs
+- `authoritative_reference`: upstream `open-webui/open-webui` tag `v0.11.0` at
+  commit `f9590b8017199e56d5e953657e6498e3cef1d246`, with PyPI source archive
+  SHA-256 `e28c4fa997bf0a678caa7a0db6441da2e0c33b9a4120677f959ec3e45fccf9e9`
+  and wheel SHA-256
+  `71c266be87d0fb2cd79d9172d0e86a3b1b59d550d7054622b831344df07d361b`
+- `advisory_references`: AUR `open-webui` packaging, including its PKGBUILD,
+  `.install`, service, and config files; upstream release, installation,
+  frontend-build, and `pyproject.toml` material
 - `divergence_notes`:
-  - This package follows the latest stable upstream release instead of the
-    older AUR package version.
-  - This package installs service assets, config defaults, user creation, and
-    state directories through normal package payloads instead of a networked
-    post-install bootstrap.
-  - This package carries a Python 3.14 compatibility patch for upstream
-    metadata and pinned dependencies whose upstream versions do not have usable
-    CPython 3.14 wheels or builds on this host.
-  - This package externalizes the ML and native scientific stack to pacman
-    packages instead of bundling PyPI's CUDA-oriented PyTorch closure.
+  - The current recipe packages `0.9.5-1`; the selected source target is
+    `0.11.0`, so the current recipe and its patches are not the accepted target.
+  - The target uses Arch Python 3.14, a repository-owned private non-ML
+    application closure, and system-owned ML and native providers. This
+    deliberately diverges from upstream's Python `<3.13` constraint and exact
+    dependency pins.
+  - Re-derive the Python 3.14 and system-ML patches against `0.11.0`: retain the
+    `<3.15` and PyArrow divergences, remove obsolete Pydantic and Psycopg
+    changes, account for the RapidOCR successor, and assert that no
+    externalized module, native library, distribution metadata, or console
+    entry remains under `/opt/open-webui`.
+  - Install service assets, secure defaults, user creation, and state
+    directories as package payloads without a networked bootstrap. The target
+    service has no Open WebUI TCP listener; it uses the normal Open WebUI
+    `serve` path over `/run/open-webui/open-webui.sock` behind same-host HTTPS
+    while preserving existing administrator choices and state.
 - `update_notes`:
-  - Diff the AUR PKGBUILD, `.install`, service unit, and config file before
-    changing package layout or dependencies.
-  - Recheck upstream `pyproject.toml`, release notes, and frontend build
-    requirements before adopting a new upstream tag.
-  - Treat Python interpreter compatibility and dependency unpinning as
-    validation gates, not metadata-only edits.
-  - Keep the private dependency tree free of `torch`, `triton`, `nvidia`,
-    `transformers`, `sentence-transformers`, ONNX Runtime, OpenCV, NumPy,
-    SciPy, pandas, PyArrow, and Pillow payloads.
+  - Keep this lane deferred and excluded from publication until the complete
+    Open WebUI G0-G4 contract passes; a source update or successful build is not
+    acceptance.
+  - G0 must verify immutable sources and hashes, regenerated `.SRCINFO`, the
+    exact Python 3.14/provider matrix and intentional upstream-pin divergences,
+    patch intent, baseline metadata, and absence of secret or host-specific
+    material.
+  - G1 must produce clean packages with the declared Python and Node toolchains,
+    build the frontend, inspect the full payload and service assets, and enforce
+    the externalized-payload denylist.
+  - G2 must install the exact CPU-forced provider set and pass offline RapidOCR,
+    deterministic Sentence Transformers save/load, CTranslate2 model and
+    malformed-model, Faster Whisper `int8` transcription and word-timestamp,
+    Open WebUI import/version, and `pacman -Qo` ownership checks.
+  - G3 must prove Unix-socket-only application service behind HTTPS `:443`,
+    service hardening and identity, state/config/secret modes, effective
+    persisted household access and privacy behavior, provider integration, and
+    no unexpected egress.
+  - G4 must pass browser workflows, cross-user privacy negatives, resource
+    limits, both required migration fixtures, state preservation, and
+    whole-runtime backup/restore rollback.
 
 ## System ML Stack
 

--- a/packages/python-backoff/README.md
+++ b/packages/python-backoff/README.md
@@ -1,0 +1,17 @@
+# python-backoff
+
+Arch package for the Python `backoff` retry-decorator library.
+
+## Maintenance Baseline
+
+- `authoritative_reference`: AUR
+  [`python-backoff`](https://aur.archlinux.org/packages/python-backoff), the
+  same source-build lane as this package.
+- `advisory_references`: upstream
+  [`backoff` PyPI source and metadata](https://pypi.org/project/backoff/2.2.1/).
+- `divergence_notes`: the current recipe keeps upstream `2.2.1` and a minimal
+  Python-only dependency surface; the AUR packaging revision may advance
+  independently of the unchanged upstream source version.
+- `update_notes`: diff the AUR recipe, verify the immutable source, clean-build
+  and inspect the package on Python 3.14, and exercise its imports as part of
+  the deferred PostHog and Haystack 3 dependency closure before publication.

--- a/packages/python-docstring-parser/README.md
+++ b/packages/python-docstring-parser/README.md
@@ -1,0 +1,18 @@
+# python-docstring-parser
+
+Arch package for the Python `docstring-parser` library used by Haystack and
+Hayhooks.
+
+## Maintenance Baseline
+
+- `authoritative_reference`: AUR
+  [`python-docstring-parser`](https://aur.archlinux.org/packages/python-docstring-parser),
+  the same source-build and version lane as this package.
+- `advisory_references`: upstream
+  [`docstring-parser` PyPI source and metadata](https://pypi.org/project/docstring-parser/0.18.0/).
+- `divergence_notes`: the current recipe packages upstream `0.18.0` as an
+  architecture-independent wheel with only Python as a runtime dependency; no
+  package-specific divergence is currently selected.
+- `update_notes`: diff the AUR recipe, verify the immutable source, clean-build
+  and inspect the package on Python 3.14, and prove imports in the deferred
+  Haystack 3 and Hayhooks lane before publication.

--- a/packages/python-fastapi-openai-compat/README.md
+++ b/packages/python-fastapi-openai-compat/README.md
@@ -1,0 +1,20 @@
+# python-fastapi-openai-compat
+
+Arch package for the FastAPI router factory used by Hayhooks to expose
+OpenAI-compatible endpoints.
+
+## Maintenance Baseline
+
+- `authoritative_reference`: upstream
+  [`fastapi-openai-compat` PyPI source and metadata](https://pypi.org/project/fastapi-openai-compat/1.2.0/);
+  no same-name Arch or AUR recipe was available at the 2026-08 refresh.
+- `advisory_references`: upstream
+  [`fastapi-openai-compat` source](https://github.com/deepset-ai/fastapi-openai-compat)
+  and Hayhooks release metadata.
+- `divergence_notes`: the current recipe packages upstream `1.2.0` from its
+  source distribution with pacman-owned FastAPI, Pydantic, and multipart
+  dependencies; this remains the selected supporting version for Hayhooks
+  `1.23.0`.
+- `update_notes`: verify the immutable source, clean-build and inspect the
+  package on Python 3.14, then prove request and response compatibility through
+  the deferred Hayhooks REST and OpenAI-compatible API gate before publication.

--- a/packages/python-faster-whisper/README.md
+++ b/packages/python-faster-whisper/README.md
@@ -7,17 +7,29 @@ bundling Faster Whisper and CTranslate2 inside the Open WebUI package.
 
 ## Maintenance Baseline
 
-- `authoritative_reference`: `aur/python-faster-whisper`
-- `advisory_references`: upstream `SYSTRAN/faster-whisper` release notes
+- `authoritative_reference`: upstream `SYSTRAN/faster-whisper` release `1.2.1`,
+  the exact selected Open WebUI speech target
+- `advisory_references`: AUR `python-faster-whisper` source-package recipe and
+  upstream Faster Whisper release and installation documentation
 - `divergence_notes`:
-  - This package keeps the AUR source-build shape.
-  - It depends on generic `python-ctranslate2` and `python-onnxruntime` provider
-    names so optimized providers can satisfy them.
-  - ROCm-accelerated CTranslate2 remains out of scope for this repo.
+  - The current package `1.2.1-1` already matches the selected application
+    version, but it has not passed the selected speech acceptance contract.
+  - Preserve the AUR source-build shape and generic `python-ctranslate2` and
+    `python-onnxruntime` provider dependencies. The accepted set must compose
+    with CTranslate2 `4.8.1` and the exact Python 3.14/system-provider profile.
+  - ROCm-accelerated CTranslate2 remains outside this repository's lane.
 - `update_notes`:
-  - Diff `aur/python-faster-whisper` before updating.
-  - Recheck whether the sibling repo provides a ROCm-aware
-    `python-ctranslate2` replacement before changing runtime expectations.
+  - Keep this package deferred and excluded from publication until the complete
+    Open WebUI speech G0-G2 gate passes; matching the selected version is not
+    acceptance.
+  - G0 must verify immutable `1.2.1` sources and checksums, regenerated
+    `.SRCINFO`, package-baseline metadata, and the exact speech compatibility
+    matrix with CTranslate2 `4.8.1`.
+  - G1 must clean-build and inspect the package and dependency payload without
+    undeclared runtime acquisition or a bundled provider stack.
+  - G2 must run offline CPU `int8` transcription and word timestamps against
+    the pinned tiny model and JFK audio fixture after the required CTranslate2
+    CPU/OpenBLAS model, malformed-model, and ownership checks pass.
 
 ## Verification
 

--- a/packages/python-lazy-imports/README.md
+++ b/packages/python-lazy-imports/README.md
@@ -1,0 +1,18 @@
+# python-lazy-imports
+
+Arch package for the Python `lazy-imports` support library used by Haystack.
+
+## Maintenance Baseline
+
+- `authoritative_reference`: upstream
+  [`lazy-imports` PyPI source and metadata](https://pypi.org/project/lazy-imports/1.2.0/);
+  no same-name Arch or AUR recipe was available at the 2026-08 refresh.
+- `advisory_references`: upstream
+  [`lazy-imports` source](https://github.com/bachorp/lazy-imports) and Haystack's
+  declared dependency metadata.
+- `divergence_notes`: the current recipe packages upstream `1.2.0` from its
+  source distribution with only Python as a runtime dependency; this remains
+  the selected supporting version for Haystack `3.0.0`.
+- `update_notes`: verify the immutable source, clean-build and inspect the
+  package on Python 3.14, then prove its imports in the deferred Haystack 3
+  offline behavior and migration gates before publication.

--- a/packages/python-posthog/README.md
+++ b/packages/python-posthog/README.md
@@ -1,0 +1,21 @@
+# python-posthog
+
+Arch package for the PostHog Python client used by Haystack's optional
+telemetry integration.
+
+## Maintenance Baseline
+
+- `authoritative_reference`: upstream
+  [`posthog` 7.38.4 release and source](https://github.com/PostHog/posthog-python/releases/tag/posthog-v7.38.4),
+  because the same-lane AUR recipe trails the selected release.
+- `advisory_references`: AUR
+  [`python-posthog`](https://aur.archlinux.org/packages/python-posthog) for Arch
+  packaging shape and upstream PyPI metadata for dependency constraints.
+- `divergence_notes`: the current recipe packages upstream `7.16.2`; the
+  selected `7.38.4` destination includes a substantial outbound-reporting and
+  privacy delta and has not yet been accepted. Haystack telemetry must remain
+  off when unset and available only through an explicit, reversible opt-in.
+- `update_notes`: freeze and verify the selected source, diff the AUR packaging,
+  audit dependency and reporting changes, clean-build and inspect the package
+  on Python 3.14, then prove fail-closed telemetry behavior as part of the
+  deferred Haystack 3 and Hayhooks lane before publication.

--- a/packages/python-sentence-transformers/README.md
+++ b/packages/python-sentence-transformers/README.md
@@ -7,16 +7,33 @@ reranking support through the system PyTorch and Transformers stack.
 
 ## Maintenance Baseline
 
-- `authoritative_reference`: `aur/python-sentence-transformers`
-- `advisory_references`: upstream `UKPLab/sentence-transformers` release notes
+- `authoritative_reference`: upstream `UKPLab/sentence-transformers` release
+  `5.5.1`, the exact target for the first accepted Open WebUI set
+- `advisory_references`: AUR `python-sentence-transformers` source-package
+  recipe and upstream Sentence Transformers release and installation material
 - `divergence_notes`:
-  - This package keeps the AUR source-build shape.
-  - Dependencies use generic Arch virtual names so the sibling ROCm/gfx1151
-    packages can satisfy PyTorch, Transformers, NumPy, and Pillow.
+  - The current package `5.5.1-1` already matches the selected application
+    version, but it has not passed the selected core acceptance contract.
+    Sentence Transformers `5.7.0` is a later compatibility candidate, not this
+    baseline's target.
+  - Preserve the AUR source-build shape and generic Arch provider dependencies,
+    but resolve them for acceptance to the exact Python/gfx1151 `3.14.6`,
+    Transformers `5.8.1`, Tokenizers `0.22.2`, Accelerate `1.13.0`,
+    SentencePiece `0.2.1`, PyTorch `2.12.0`, NumPy `2.4.6`, Pillow `12.2.0`,
+    SciPy `1.18.0`, and scikit-learn `1.9.0` profile.
 - `update_notes`:
-  - Diff `aur/python-sentence-transformers` before updating.
-  - Recheck dependency metadata against the system PyTorch and Transformers
-    providers before accepting a new upstream version.
+  - Keep this package deferred and excluded from publication until the exact
+    Python 3.14/system-ML checks and the composed Open WebUI core G0-G4 gate
+    pass; matching `5.5.1` is not acceptance.
+  - G0-G1 must verify the immutable source and dependency metadata, regenerate
+    `.SRCINFO`, clean-build the source package, inspect its payload, and record
+    the exact provider matrix without bundling the system ML stack.
+  - G2 must run a deterministic offline embedding and save/load check against
+    the pinned tiny safetensors fixture under the exact installed CPU-forced
+    provider set, including `pacman -Qo` ownership evidence.
+  - G3-G4 must pass the composed Open WebUI service, API, privacy, persistence,
+    browser, migration, preservation, and whole-runtime rollback gates before
+    this core dependency can be accepted.
 
 ## Verification
 

--- a/packages/qdrant/README.md
+++ b/packages/qdrant/README.md
@@ -5,6 +5,27 @@ Native Arch package for the Qdrant vector database.
 Use this package when you want a local vector store managed by pacman and
 `systemd`, with conservative localhost defaults.
 
+## Maintenance Baseline
+
+- `authoritative_reference`: AUR
+  [`qdrant`](https://aur.archlinux.org/packages/qdrant) at the selected `1.18.3`
+  migration baseline.
+- `advisory_references`: upstream Qdrant
+  [releases](https://github.com/qdrant/qdrant/releases),
+  [upgrade guidance](https://qdrant.tech/documentation/upgrades/), and the
+  [`qdrant-web-ui` releases](https://github.com/qdrant/qdrant-web-ui/releases).
+- `divergence_notes`: the current `1.18.1-2` recipe adds a dedicated user,
+  loopback-only hardened service, pacman-managed configuration and state paths,
+  and telemetry-disabled defaults. The selected route uses `1.18.3` as a
+  mandatory migration intermediate before `1.19.0`, then adds a separately
+  packaged Web UI plus fail-closed scoped authentication and response headers;
+  that destination has not yet been accepted.
+- `update_notes`: verify pinned release identities and hashes, clean-build and
+  inspect the server, intermediate, and Web UI packages, then pass disposable
+  fresh-runtime, authentication, consecutive-minor migration, snapshot and
+  cold-copy recovery, corruption-rejection, rollback, and complete
+  Haystack/Hayhooks HTTP and gRPC composition gates before publication.
+
 ## Package Contents
 
 - `qdrant` binary

--- a/packages/thorium-browser-updated/README.md
+++ b/packages/thorium-browser-updated/README.md
@@ -14,27 +14,50 @@ Chromium tarball and Thorium release tag recipe.
 
 ## Maintenance Baseline
 
-- `authoritative_reference`: AUR `thorium-browser-updated`
-- `advisory_references`: AUR `thorium-browser-bin`,
-  `thorium-browser-avx-bin`, `thorium-browser-avx2-bin`, upstream Thorium
-  release notes, and Chromium source release/build notes
+- `authoritative_reference`: AUR `alacrium-browser`, the primary Arch-facing
+  reference for the selected source-built Alacrium successor lane
+- `advisory_references`: upstream Alacrium release and build documentation, AUR
+  `alacrium-browser-bin`, and same-version Arch Chromium packaging
 - `divergence_notes`:
-  - This package tracks the fixed local AUR working recipe for
-    `149.0.7827.114-4`.
-  - This package uses the reachable Thorium tag
-    `M149.0.7827.114-updated`.
-  - This package uses the official Chromium source tarball instead of a full
-    Chromium git checkout.
-  - This package keeps the build-time compatibility patches needed for the
-    Thorium setup scripts, Chromium media defaults, GN args, and RPM staging
-    assumptions.
+  - The current package is Thorium `149.0.7827.114-4` at tag
+    `M149.0.7827.114-updated`. The selected maintained lane is the independent
+    Alacrium fork, researched at `M151.0.7922.108`; implementation must still
+    freeze the newest eligible release aligned with current Chromium stable and
+    its security fixes.
+  - The successor package and executable are `alacrium-browser`, with AVX as an
+    explicit minimum. It replaces and conflicts with
+    `thorium-browser-updated` only after acceptance, provides no Thorium alias,
+    and never automatically reads, moves, converts, or deletes the Thorium
+    profile.
+  - Re-derive named, context-checked patches against the frozen Alacrium and
+    Chromium sources rather than wholesale-porting the current Thorium patch
+    set. Capture every build input in an immutable offline source bundle.
+  - Ship separate normal and experimental launch contracts over the same
+    browser with isolated profiles, caches, flags, and desktop identities, plus
+    the selected privacy and security defaults and no package-owned updater.
 - `update_notes`:
-  - Diff AUR `thorium-browser-updated` before changing the source, dependency,
-    or install behavior.
-  - Recheck Thorium tag reachability and Chromium source tarball availability
-    before updating `.SRCINFO`.
-  - Keep source download, full build, and package payload inspection as explicit
-    validation work because Chromium/Thorium builds are expensive.
+  - Keep this lane deferred and excluded from publication, and preserve the
+    Thorium source/profile evidence, until the Alacrium successor passes all
+    G0-G4 gates. The researched release cursor is not acceptance.
+  - G0 must freeze the newest eligible release, verify Chromium security
+    alignment with no known missing critical or high fix, and complete the
+    immutable source manifest, dependency/license review, patch review, and
+    offline bundle.
+  - G1 must produce two clean networking-disabled builds from that bundle in
+    the specified Arch x86_64 AVX environment and explain their structural
+    differences while staying within the build resource ceilings.
+  - G2 must inspect payload, ownership, modes, licenses, SBOM, privileges,
+    update behavior, sandbox layers, the single expected mode-4755
+    `chrome-sandbox`, and absence of undeclared services, downloads, forced
+    extensions, capabilities, and host mutation.
+  - G3 must prove isolated normal and experimental launchers on Wayland and
+    X11, profile separation, sandbox health, media/PDF/WebRTC/VA-API behavior,
+    downloads, desktop/MIME integration, extension installation, and clean
+    removal.
+  - G4 must pass egress and privacy checks, package and runtime resource
+    ceilings, profile/cache growth checks, replacement behavior, Thorium-profile
+    preservation, deployment recovery, and package rollback before Thorium is
+    retired.
 
 ## Verification
 

--- a/packages/utilyze/README.md
+++ b/packages/utilyze/README.md
@@ -6,6 +6,26 @@ Use [`README.Arch.md`](README.Arch.md) for user-facing behavior, first-run
 guidance, telemetry consent, and the current verified/not-verified boundary.
 That file is installed as `/usr/share/doc/utilyze/README.Arch.md`.
 
+## Maintenance Baseline
+
+- `authoritative_reference`: upstream
+  [`utilyze` v0.1.3 source and release metadata](https://github.com/systalyze/utilyze/releases/tag/v0.1.3);
+  no same-name Arch or AUR recipe was available at the 2026-08 refresh.
+- `advisory_references`: Arch CUDA and NVIDIA package layouts, NVIDIA profiling
+  and CUPTI documentation, and this repository's
+  [selected validation rig](../../docs/maintainers/utilyze-nvidia-validation-rig.md).
+- `divergence_notes`: the current `0.1.1-2` recipe carries Arch CUDA-path,
+  profiling-policy, package-update, configuration, and telemetry-consent
+  patches. The selected `0.1.3` destination must rederive those behaviors for
+  upstream's client/server and JSON-config architecture, drop the obsolete
+  generic-config patch, and build the native sampler explicitly; it has not
+  passed the required acceptance gate.
+- `update_notes`: verify the pinned source and patch intent, clean-build and
+  inspect the package and embedded native sampler without runtime bootstrap or
+  update traffic, then pass config migration, fail-closed telemetry, service
+  ownership, and live Ampere-or-newer NVIDIA/CUPTI TUI acceptance before this
+  deferred lane becomes publication-eligible.
+
 ## What This Directory Adds
 
 - Arch package recipe in `PKGBUILD`

--- a/tests/test_ingest_chatgpt_linux.py
+++ b/tests/test_ingest_chatgpt_linux.py
@@ -1038,7 +1038,9 @@ class ChatGPTLinuxIngestTests(unittest.TestCase):
 
     def test_signal_during_update_lock_acquisition_cleans_the_owned_lock(self):
         package_dir = self.root / "update-package"
+        fake_bin = self.root / "update-lock-bin"
         package_dir.mkdir()
+        fake_bin.mkdir()
         (package_dir / "PKGBUILD").write_text(
             "pkgname=chatgpt\n"
             "pkgver=26.810.52044\n"
@@ -1047,13 +1049,29 @@ class ChatGPTLinuxIngestTests(unittest.TestCase):
             "package() { :; }\n",
             encoding="utf-8",
         )
-        shutil.copy2(self.artifact, package_dir / self.artifact.name)
+        package_archive = package_dir / self.artifact.name
+        shutil.copy2(self.artifact, package_archive)
+        fake_makepkg = fake_bin / "makepkg"
+        fake_makepkg.write_text(
+            f"#!{sys.executable}\n"
+            "import sys\n"
+            f"package = {str(package_archive)!r}\n"
+            "if sys.argv[1:] == ['--packagelist']:\n"
+            "    print(package)\n"
+            "elif sys.argv[1:] == ['--printsrcinfo']:\n"
+            "    print('pkgname = chatgpt')\n"
+            "else:\n"
+            "    raise SystemExit(2)\n",
+            encoding="utf-8",
+        )
+        fake_makepkg.chmod(0o755)
         environment = os.environ.copy()
         for key in list(environment):
             if key.startswith("BASH_FUNC_"):
                 del environment[key]
         environment["ARCH_PKGS_UPDATE_TEST_SIGNAL_DURING_LOCK_ACQUISITION"] = "1"
         environment["ARCH_PKGS_UPDATE_TEST_MODE"] = "1"
+        environment["PATH"] = f"{fake_bin}:{environment['PATH']}"
 
         result = subprocess.run(
             [

--- a/tests/test_repo_consistency.py
+++ b/tests/test_repo_consistency.py
@@ -160,6 +160,53 @@ class RepositoryConsistencyTests(unittest.TestCase):
             result.stderr,
         )
 
+    def test_srcinfo_identity_requires_named_version_fields(self):
+        for name in (".SRCINFO", ".generated-srcinfo"):
+            srcinfo = self.repo / "packages/example" / name
+            srcinfo.write_text(
+                srcinfo.read_text(encoding="utf-8").replace(
+                    "\tpkgver = 1.2.3\n", ""
+                ),
+                encoding="utf-8",
+            )
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "packages/example/.SRCINFO: required field pkgver must appear exactly once and be nonempty",
+            result.stderr,
+        )
+        self.assertNotIn("Traceback", result.stderr)
+
+    def test_chatgpt_identity_requires_object_package_metadata(self):
+        baseline_readme = (self.repo / "packages/example/README.md").read_text(
+            encoding="utf-8"
+        )
+        for name in ("PKGBUILD", ".SRCINFO", ".generated-srcinfo", "README.md"):
+            (self.repo / "packages/example" / name).unlink()
+        catalog = self.repo / "packages/README.md"
+        catalog.write_text(
+            catalog.read_text(encoding="utf-8")
+            .replace("[`example`](example/)", "[`chatgpt`](chatgpt/)")
+            .replace("| `example` | 1.2.3-4 |", "| `chatgpt` | 1.0-1 |"),
+            encoding="utf-8",
+        )
+        self.write("packages/chatgpt/README.md", baseline_readme)
+        self.write(
+            "packages/chatgpt/fallback-baseline-fixture.json",
+            '{"package": []}\n',
+        )
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "packages/chatgpt/fallback-baseline-fixture.json: package must be an object",
+            result.stderr,
+        )
+        self.assertNotIn("Traceback", result.stderr)
+
     def test_catalog_must_cover_each_package_lane_once(self):
         self.write(
             "packages/README.md",
@@ -314,22 +361,21 @@ class RepositoryConsistencyTests(unittest.TestCase):
             result.stderr,
         )
 
-    def test_catalog_requires_deferred_lane_to_be_excluded(self):
+    def test_catalog_allows_deferred_lane_with_previous_publishable_version(self):
         catalog = self.repo / "packages/README.md"
         catalog.write_text(
-            catalog.read_text(encoding="utf-8").replace(
-                "| accepted-current |", "| deferred |"
+            catalog.read_text(encoding="utf-8")
+            .replace("| accepted-current |", "| deferred |")
+            .replace(
+                "| Fixture acceptance passed |",
+                "| Previously accepted 1.2.3 remains publishable |",
             ),
             encoding="utf-8",
         )
 
         result = self.run_checker()
 
-        self.assertEqual(result.returncode, 1)
-        self.assertIn(
-            "packages/README.md: example deferred lane must not be publication eligible",
-            result.stderr,
-        )
+        self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_retained_lane_requires_complete_baseline(self):
         readme = self.repo / "packages/example/README.md"
@@ -362,6 +408,46 @@ class RepositoryConsistencyTests(unittest.TestCase):
         self.assertEqual(result.returncode, 1)
         self.assertIn(
             "packages/example/README.md: required section ## Maintenance Baseline must appear exactly once",
+            result.stderr,
+        )
+
+    def test_blank_baseline_field_does_not_borrow_a_later_nested_bullet(self):
+        readme = self.repo / "packages/example/README.md"
+        readme.write_text(
+            readme.read_text(encoding="utf-8").replace(
+                "- `authoritative_reference`: upstream example release\n",
+                "- `authoritative_reference`:\n"
+                "- unrelated note\n"
+                "  nested continuation\n",
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "packages/example/README.md: required baseline field authoritative_reference must appear exactly once and be nonempty",
+            result.stderr,
+        )
+
+    def test_blank_baseline_field_does_not_borrow_an_alternate_list(self):
+        readme = self.repo / "packages/example/README.md"
+        readme.write_text(
+            readme.read_text(encoding="utf-8").replace(
+                "- `authoritative_reference`: upstream example release\n",
+                "- `authoritative_reference`:\n"
+                "* unrelated note\n"
+                "  nested continuation\n",
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "packages/example/README.md: required baseline field authoritative_reference must appear exactly once and be nonempty",
             result.stderr,
         )
 

--- a/tests/test_repo_consistency.py
+++ b/tests/test_repo_consistency.py
@@ -1,0 +1,569 @@
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHECKER = REPO_ROOT / "tools" / "check_repo_consistency.py"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "repository-consistency.yml"
+
+
+class RepositoryConsistencyTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory(dir="/tmp")
+        self.addCleanup(self.tempdir.cleanup)
+        self.repo = Path(self.tempdir.name) / "repo"
+        self.bin_dir = Path(self.tempdir.name) / "bin"
+        self.repo.mkdir()
+        self.bin_dir.mkdir()
+
+        subprocess.run(["git", "init", "-q", str(self.repo)], check=True)
+        self.write(
+            "packages/example/PKGBUILD",
+            "pkgname=example\npkgver=1.2.3\npkgrel=4\narch=('any')\n",
+        )
+        srcinfo = textwrap.dedent(
+            """\
+            pkgbase = example
+            \tpkgver = 1.2.3
+            \tpkgrel = 4
+            \tarch = any
+
+            pkgname = example
+            """
+        )
+        self.write("packages/example/.SRCINFO", srcinfo)
+        self.write("packages/example/.generated-srcinfo", srcinfo)
+        self.write(
+            "packages/example/README.md",
+            textwrap.dedent(
+                """\
+                # example
+
+                ## Maintenance Baseline
+
+                - `authoritative_reference`: upstream example release
+                - `advisory_references`: Arch package guidelines
+                - `divergence_notes`: packages the upstream source without patches
+                - `update_notes`: verify the source and regenerate `.SRCINFO`
+                """
+            ),
+        )
+        self.write(
+            "packages/README.md",
+            textwrap.dedent(
+                """\
+                # Package Catalog
+
+                | Directory | Package | Packaged version | Disposition | Reviewed target or cursor | Review date | Acceptance state or next gate | Publication eligible |
+                | --- | --- | --- | --- | --- | --- | --- | --- |
+                | [`example`](example/) | `example` | 1.2.3-4 | accepted-current | 1.2.3 | 2026-08-17 | Fixture acceptance passed | yes |
+                """
+            ),
+        )
+        self.write("tools/example.zsh", "#!/usr/bin/env zsh\nprint -r -- ok\n")
+        self.write("tests/__init__.py", "")
+        self.write("tests/test_fixture.py", "import unittest\n")
+        self.write(
+            ".github/workflows/example.yml",
+            textwrap.dedent(
+                """\
+                name: Example
+                jobs:
+                  example:
+                    steps:
+                      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+                """
+            ),
+        )
+        makepkg = self.bin_dir / "makepkg"
+        makepkg.write_text(
+            "#!/bin/sh\n"
+            "test \"$1\" = --printsrcinfo || exit 64\n"
+            "cat .generated-srcinfo\n",
+            encoding="utf-8",
+        )
+        makepkg.chmod(0o755)
+        subprocess.run(
+            [
+                "git",
+                "add",
+                "packages/example/PKGBUILD",
+                "packages/example/.SRCINFO",
+                "packages/example/README.md",
+                "packages/README.md",
+                "tools/example.zsh",
+                "tests/__init__.py",
+                "tests/test_fixture.py",
+                ".github/workflows/example.yml",
+            ],
+            cwd=self.repo,
+            check=True,
+        )
+
+    def write(self, relative_path: str, content: str) -> None:
+        path = self.repo / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    def run_checker(
+        self, *arguments: str, skip_tests: bool = True
+    ) -> subprocess.CompletedProcess[str]:
+        environment = os.environ.copy()
+        environment["PATH"] = f"{self.bin_dir}:{environment['PATH']}"
+        command = [sys.executable, str(CHECKER), "--repo", str(self.repo)]
+        if skip_tests:
+            command.append("--skip-tests")
+        command.extend(arguments)
+        return subprocess.run(
+            command,
+            cwd=REPO_ROOT,
+            env=environment,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_conforming_repository_passes(self):
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("repository consistency: passed", result.stdout)
+
+    def test_package_lane_requires_srcinfo(self):
+        (self.repo / "packages/example/.SRCINFO").unlink()
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "packages/example: PKGBUILD and .SRCINFO must both exist",
+            result.stderr,
+        )
+
+    def test_srcinfo_must_match_makepkg_output(self):
+        srcinfo = self.repo / "packages/example/.SRCINFO"
+        srcinfo.write_text(
+            srcinfo.read_text(encoding="utf-8").replace("pkgver = 1.2.3", "pkgver = 9.9.9"),
+            encoding="utf-8",
+        )
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "packages/example/.SRCINFO does not match makepkg --printsrcinfo",
+            result.stderr,
+        )
+
+    def test_catalog_must_cover_each_package_lane_once(self):
+        self.write(
+            "packages/README.md",
+            "# Package Catalog\n\nNo package rows are present.\n",
+        )
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "packages/README.md: package lane example must appear exactly once; found 0",
+            result.stderr,
+        )
+
+    def test_empty_legacy_directory_is_not_a_package_lane(self):
+        (self.repo / "packages/codex-app").mkdir()
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_catalog_rejects_duplicate_package_lane(self):
+        catalog = self.repo / "packages/README.md"
+        catalog.write_text(
+            catalog.read_text(encoding="utf-8")
+            + "| [`example`](example/) | `example` | 1.2.3-4 | accepted-current | 1.2.3 | 2026-08-17 | Fixture acceptance passed | yes |\n",
+            encoding="utf-8",
+        )
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "packages/README.md: package lane example must appear exactly once; found 2",
+            result.stderr,
+        )
+
+    def test_catalog_version_must_match_srcinfo(self):
+        catalog = self.repo / "packages/README.md"
+        catalog.write_text(
+            catalog.read_text(encoding="utf-8").replace(
+                "| `example` | 1.2.3-4 |", "| `example` | 9.9.9-1 |"
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "packages/README.md: example packaged version 9.9.9-1 does not match 1.2.3-4",
+            result.stderr,
+        )
+
+    def test_catalog_package_names_must_match_srcinfo(self):
+        catalog = self.repo / "packages/README.md"
+        catalog.write_text(
+            catalog.read_text(encoding="utf-8").replace(
+                "| `example` | 1.2.3-4 |", "| `wrong-name` | 1.2.3-4 |"
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "packages/README.md: example package names ['wrong-name'] do not match ['example']",
+            result.stderr,
+        )
+
+    def test_catalog_rejects_unknown_disposition(self):
+        catalog = self.repo / "packages/README.md"
+        catalog.write_text(
+            catalog.read_text(encoding="utf-8").replace(
+                "| accepted-current |", "| current |"
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "packages/README.md: example has invalid disposition current",
+            result.stderr,
+        )
+
+    def test_catalog_requires_iso_review_date(self):
+        catalog = self.repo / "packages/README.md"
+        catalog.write_text(
+            catalog.read_text(encoding="utf-8").replace(
+                "| 2026-08-17 |", "| 20260817 |"
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "packages/README.md: example review date must be ISO YYYY-MM-DD",
+            result.stderr,
+        )
+
+    def test_catalog_requires_publication_eligibility(self):
+        catalog = self.repo / "packages/README.md"
+        catalog.write_text(
+            catalog.read_text(encoding="utf-8").replace(
+                "| yes |", "| maybe |"
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "packages/README.md: example publication eligibility must be yes or no",
+            result.stderr,
+        )
+
+    def test_catalog_requires_accepted_lane_to_be_publication_eligible(self):
+        catalog = self.repo / "packages/README.md"
+        catalog.write_text(
+            catalog.read_text(encoding="utf-8").replace("| yes |", "| no |"),
+            encoding="utf-8",
+        )
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "packages/README.md: example accepted-current lane must be publication eligible",
+            result.stderr,
+        )
+
+    def test_catalog_requires_retired_lane_to_be_excluded(self):
+        catalog = self.repo / "packages/README.md"
+        catalog.write_text(
+            catalog.read_text(encoding="utf-8").replace(
+                "| accepted-current |", "| retired |"
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "packages/README.md: example retired lane must not be publication eligible",
+            result.stderr,
+        )
+
+    def test_catalog_requires_deferred_lane_to_be_excluded(self):
+        catalog = self.repo / "packages/README.md"
+        catalog.write_text(
+            catalog.read_text(encoding="utf-8").replace(
+                "| accepted-current |", "| deferred |"
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "packages/README.md: example deferred lane must not be publication eligible",
+            result.stderr,
+        )
+
+    def test_retained_lane_requires_complete_baseline(self):
+        readme = self.repo / "packages/example/README.md"
+        readme.write_text(
+            readme.read_text(encoding="utf-8").replace(
+                "- `update_notes`: verify the source and regenerate `.SRCINFO`\n", ""
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "packages/example/README.md: required baseline field update_notes must appear exactly once and be nonempty",
+            result.stderr,
+        )
+
+    def test_retained_lane_requires_one_exact_baseline_section(self):
+        readme = self.repo / "packages/example/README.md"
+        readme.write_text(
+            readme.read_text(encoding="utf-8").replace(
+                "## Maintenance Baseline", "## Maintenance baseline"
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "packages/example/README.md: required section ## Maintenance Baseline must appear exactly once",
+            result.stderr,
+        )
+
+    def test_retired_lane_is_exempt_from_baseline_fields(self):
+        catalog = self.repo / "packages/README.md"
+        catalog.write_text(
+            catalog.read_text(encoding="utf-8")
+            .replace("| accepted-current |", "| retired |")
+            .replace("| yes |", "| no |"),
+            encoding="utf-8",
+        )
+        (self.repo / "packages/example/README.md").unlink()
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_catalog_supports_split_packages_and_epoch(self):
+        srcinfo = textwrap.dedent(
+            """\
+            pkgbase = example
+            \tepoch = 2
+            \tpkgver = 1.2.3
+            \tpkgrel = 4
+            \tarch = any
+
+            pkgname = example
+
+            pkgname = example-extra
+            """
+        )
+        self.write("packages/example/.SRCINFO", srcinfo)
+        self.write("packages/example/.generated-srcinfo", srcinfo)
+        catalog = self.repo / "packages/README.md"
+        catalog.write_text(
+            catalog.read_text(encoding="utf-8")
+            .replace("| `example` |", "| `example`, `example-extra` |")
+            .replace("| 1.2.3-4 |", "| 2:1.2.3-4 |"),
+            encoding="utf-8",
+        )
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_tracked_zsh_must_parse(self):
+        self.write("tools/example.zsh", "#!/usr/bin/env zsh\nif true; then\n")
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("tools/example.zsh: zsh syntax check failed", result.stderr)
+        self.assertNotIn(str(self.repo), result.stderr)
+
+    def test_workflow_actions_must_use_full_commit_shas(self):
+        workflow = self.repo / ".github/workflows/example.yml"
+        workflow.write_text(
+            workflow.read_text(encoding="utf-8").replace(
+                "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
+                "actions/checkout@v4",
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            ".github/workflows/example.yml: action must use a full commit SHA: actions/checkout@v4",
+            result.stderr,
+        )
+
+    def test_workflow_action_pin_check_parses_valid_yaml_forms(self):
+        workflow = self.repo / ".github/workflows/example.yml"
+        cases = {
+            "inline mapping": "steps:\n      - { uses: actions/checkout@v4 }\n",
+            "quoted key": 'steps:\n      - "uses": actions/checkout@v4\n',
+            "spaced separator": "steps:\n      - uses : actions/checkout@v4\n",
+            "reusable workflow": "uses: owner/repository/.github/workflows/reuse.yml@main\n",
+        }
+        for label, job_body in cases.items():
+            with self.subTest(label=label):
+                workflow.write_text(
+                    "name: Example\njobs:\n  example:\n    " + job_body,
+                    encoding="utf-8",
+                )
+
+                result = self.run_checker()
+
+                self.assertEqual(result.returncode, 1)
+                self.assertIn("action must use a full commit SHA", result.stderr)
+
+    def test_workflow_accepts_quoted_full_commit_sha(self):
+        workflow = self.repo / ".github/workflows/example.yml"
+        workflow.write_text(
+            textwrap.dedent(
+                """\
+                name: Example
+                jobs:
+                  example:
+                    steps:
+                      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"
+                """
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_workflow_accepts_checkout_local_action(self):
+        workflow = self.repo / ".github/workflows/example.yml"
+        workflow.write_text(
+            "name: Example\njobs:\n  example:\n    steps:\n      - uses: ./actions/local\n",
+            encoding="utf-8",
+        )
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_invalid_workflow_yaml_fails_closed(self):
+        workflow = self.repo / ".github/workflows/example.yml"
+        workflow.write_text("name: [unterminated\n", encoding="utf-8")
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            ".github/workflows/example.yml: workflow YAML is invalid",
+            result.stderr,
+        )
+
+    def test_workflow_action_pin_check_preserves_yaml_boolean_like_job_ids(self):
+        workflow = self.repo / ".github/workflows/example.yml"
+        workflow.write_text(
+            textwrap.dedent(
+                """\
+                name: Example
+                jobs:
+                  yes:
+                    steps:
+                      - uses: actions/checkout@v4
+                  true:
+                    steps:
+                      - run: echo safe
+                """
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("action must use a full commit SHA", result.stderr)
+
+    def test_default_gate_runs_committed_unit_tests(self):
+        self.write(
+            "tests/test_failure.py",
+            textwrap.dedent(
+                """\
+                import unittest
+
+                class FailureTest(unittest.TestCase):
+                    def test_failure(self):
+                        self.fail("fixture unit-test failure")
+                """
+            ),
+        )
+
+        result = self.run_checker(skip_tests=False)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("fixture unit-test failure", result.stderr)
+        self.assertNotIn("repository consistency: passed", result.stdout)
+
+
+class RepositoryConsistencyWorkflowTests(unittest.TestCase):
+    def test_workflow_runs_stable_unprivileged_gate_on_prs_and_main(self):
+        text = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("pull_request:\n", text)
+        self.assertIn("push:\n    branches:\n      - main\n", text)
+        self.assertNotIn("paths:", text)
+        self.assertIn("permissions:\n  contents: read\n", text)
+        self.assertIn("name: Repository consistency\n", text)
+        self.assertIn("image: archlinux:base-devel\n", text)
+        self.assertIn(
+            "uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
+            text,
+        )
+        self.assertIn("persist-credentials: false", text)
+        self.assertIn("runuser -u consistency", text)
+        self.assertIn("python-yaml", text)
+        self.assertIn("python3 tools/check_repo_consistency.py", text)
+        self.assertNotIn("--skip-tests", text)
+        self.assertLess(
+            text.index("- name: Install test dependencies"),
+            text.index("- name: Check out repository"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_repo_consistency.py
+++ b/tests/test_repo_consistency.py
@@ -6,6 +6,8 @@ import textwrap
 import unittest
 from pathlib import Path
 
+import yaml
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 CHECKER = REPO_ROOT / "tools" / "check_repo_consistency.py"
@@ -627,6 +629,86 @@ class RepositoryConsistencyTests(unittest.TestCase):
 
 
 class RepositoryConsistencyWorkflowTests(unittest.TestCase):
+    def dependency_install_script(self):
+        workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+        steps = workflow["jobs"]["consistency"]["steps"]
+        return next(
+            step["run"]
+            for step in steps
+            if step.get("name") == "Install test dependencies"
+        )
+
+    def run_dependency_install_script(self, pacman_body):
+        with tempfile.TemporaryDirectory(dir="/tmp") as tempdir:
+            root = Path(tempdir)
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            count_file = root / "pacman-attempts"
+            argument_file = root / "pacman-arguments"
+            pacman = bin_dir / "pacman"
+            pacman.write_text(
+                "#!/usr/bin/bash\n"
+                'arguments=("$@")\n'
+                'printf \'%q\' "${arguments[0]}" >> "${PACMAN_ARGUMENT_FILE}"\n'
+                'for argument in "${arguments[@]:1}"; do\n'
+                '  printf \' %q\' "${argument}" >> "${PACMAN_ARGUMENT_FILE}"\n'
+                "done\n"
+                'printf \'\\n\' >> "${PACMAN_ARGUMENT_FILE}"\n'
+                "count=0\n"
+                'if [[ -f "${PACMAN_ATTEMPT_FILE}" ]]; then\n'
+                '  IFS= read -r count < "${PACMAN_ATTEMPT_FILE}"\n'
+                "fi\n"
+                "((count += 1))\n"
+                'printf \'%s\\n\' "${count}" > "${PACMAN_ATTEMPT_FILE}"\n'
+                + pacman_body,
+                encoding="utf-8",
+            )
+            pacman.chmod(0o755)
+            sleep = bin_dir / "sleep"
+            sleep.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            sleep.chmod(0o755)
+            environment = os.environ.copy()
+            environment["PATH"] = f"{bin_dir}:/usr/bin"
+            environment["PACMAN_ATTEMPT_FILE"] = str(count_file)
+            environment["PACMAN_ARGUMENT_FILE"] = str(argument_file)
+
+            result = subprocess.run(
+                ["/usr/bin/bash", "-c", self.dependency_install_script()],
+                capture_output=True,
+                text=True,
+                env=environment,
+                timeout=5,
+                check=False,
+            )
+
+            return (
+                result,
+                int(count_file.read_text(encoding="utf-8")),
+                argument_file.read_text(encoding="utf-8").splitlines(),
+            )
+
+    def test_workflow_retries_transient_dependency_sync_failures(self):
+        result, attempts, arguments = self.run_dependency_install_script(
+            '[[ "${count}" -ge 2 ]]\n'
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(attempts, 2)
+        self.assertEqual(
+            arguments,
+            ["-Syyu --noconfirm git jq python python-yaml rsync zsh"] * attempts,
+        )
+
+    def test_workflow_dependency_sync_retry_is_bounded(self):
+        result, attempts, arguments = self.run_dependency_install_script("exit 1\n")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(attempts, 4)
+        self.assertEqual(
+            arguments,
+            ["-Syyu --noconfirm git jq python python-yaml rsync zsh"] * attempts,
+        )
+
     def test_workflow_runs_stable_unprivileged_gate_on_prs_and_main(self):
         text = WORKFLOW.read_text(encoding="utf-8")
 

--- a/tools/check_repo_consistency.py
+++ b/tools/check_repo_consistency.py
@@ -199,31 +199,63 @@ def check_catalog_coverage(repo: Path) -> list[str]:
     return errors
 
 
-def srcinfo_identity(srcinfo: Path) -> tuple[list[str], str]:
+def srcinfo_identity(repo: Path, srcinfo: Path) -> tuple[list[str], str]:
     values: dict[str, list[str]] = {}
     for line in srcinfo.read_text(encoding="utf-8").splitlines():
         if " = " not in line:
             continue
         key, value = line.strip().split(" = ", 1)
         values.setdefault(key, []).append(value)
-    version = values["pkgver"][0]
+    relative = srcinfo.relative_to(repo).as_posix()
+
+    def required_single_value(key: str) -> str:
+        matching = values.get(key, [])
+        if len(matching) != 1 or not matching[0].strip():
+            raise ValueError(
+                f"{relative}: required field {key} must appear exactly once and be nonempty"
+            )
+        return matching[0]
+
+    package_names = values.get("pkgname", [])
+    if not package_names or any(not name.strip() for name in package_names):
+        raise ValueError(
+            f"{relative}: required field pkgname must appear and be nonempty"
+        )
+    version = required_single_value("pkgver")
     if "epoch" in values:
-        version = f"{values['epoch'][0]}:{version}"
-    version = f"{version}-{values['pkgrel'][0]}"
-    return sorted(values.get("pkgname", [])), version
+        version = f"{required_single_value('epoch')}:{version}"
+    version = f"{version}-{required_single_value('pkgrel')}"
+    return sorted(package_names), version
 
 
 def package_identity(repo: Path, package_name: str) -> tuple[list[str], str]:
     package_dir = repo / "packages" / package_name
     if package_name != "chatgpt":
-        return srcinfo_identity(package_dir / ".SRCINFO")
+        return srcinfo_identity(repo, package_dir / ".SRCINFO")
     baselines = sorted(package_dir.glob("fallback-baseline-*.json"))
     if len(baselines) != 1:
         raise ValueError(
             f"packages/chatgpt: expected one fallback baseline; found {len(baselines)}"
         )
-    baseline = json.loads(baselines[0].read_text(encoding="utf-8"))
-    return [baseline["package"]["name"]], baseline["package"]["version"]
+    relative = baselines[0].relative_to(repo).as_posix()
+    try:
+        baseline = json.loads(baselines[0].read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise ValueError(f"{relative}: invalid JSON: {error.msg}") from error
+    if not isinstance(baseline, dict):
+        raise ValueError(f"{relative}: baseline must be an object")
+    package = baseline.get("package")
+    if not isinstance(package, dict):
+        raise ValueError(f"{relative}: package must be an object")
+    identity: dict[str, str] = {}
+    for key in ("name", "version"):
+        value = package.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(
+                f"{relative}: package.{key} must be a nonempty string"
+            )
+        identity[key] = value
+    return [identity["name"]], identity["version"]
 
 
 def check_catalog_identity(repo: Path) -> list[str]:
@@ -299,27 +331,24 @@ def check_catalog_shape(repo: Path) -> list[str]:
                 f"packages/README.md: {package_name} retired lane "
                 "must not be publication eligible"
             )
-        if disposition == "deferred" and row[7] == "yes":
-            errors.append(
-                f"packages/README.md: {package_name} deferred lane "
-                "must not be publication eligible"
-            )
     return errors
 
 
 def baseline_value_is_present(text: str, field: str) -> bool:
-    pattern = re.compile(rf"(?m)^- `{re.escape(field)}`:\s*(?P<value>[^\n]*)$")
+    pattern = re.compile(
+        rf"(?m)^- `{re.escape(field)}`:[ \t]*(?P<value>[^\n]*)$"
+    )
     matches = list(pattern.finditer(text))
     if len(matches) != 1:
         return False
     match = matches[0]
     if match.group("value").strip():
         return True
-    following = text[match.end() :]
-    boundary = re.search(r"(?m)^(?:- `[^`]+`:\s*|#{1,6}\s+)", following)
-    if boundary:
-        following = following[: boundary.start()]
-    return any(line.startswith(("  ", "\t")) and line.strip() for line in following.splitlines())
+    for line in text[match.end() :].splitlines():
+        if not line.strip():
+            continue
+        return line.startswith((" ", "\t"))
+    return False
 
 
 def maintenance_baseline_section(text: str) -> str | None:

--- a/tools/check_repo_consistency.py
+++ b/tools/check_repo_consistency.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+import yaml
+from yaml.nodes import MappingNode, Node, ScalarNode, SequenceNode
+
+
+def package_lane_names(repo: Path) -> set[str]:
+    names: set[str] = set()
+    for path in repository_paths(repo):
+        relative = path.relative_to(repo)
+        if len(relative.parts) >= 3 and relative.parts[0] == "packages":
+            names.add(relative.parts[1])
+    return names
+
+
+def check_package_pairs(repo: Path) -> list[str]:
+    errors: list[str] = []
+    packages_dir = repo / "packages"
+    for package_name in sorted(package_lane_names(repo)):
+        package_dir = packages_dir / package_name
+        has_pkgbuild = (package_dir / "PKGBUILD").is_file()
+        has_srcinfo = (package_dir / ".SRCINFO").is_file()
+        relative = package_dir.relative_to(repo).as_posix()
+        if package_dir.name == "chatgpt":
+            if has_pkgbuild or has_srcinfo:
+                errors.append(
+                    f"{relative}: immutable artifact lane must not contain PKGBUILD or .SRCINFO"
+                )
+        elif not (has_pkgbuild and has_srcinfo):
+            errors.append(f"{relative}: PKGBUILD and .SRCINFO must both exist")
+    return errors
+
+
+def check_srcinfo(repo: Path) -> list[str]:
+    errors: list[str] = []
+    for package_dir in sorted((repo / "packages").iterdir()):
+        if not package_dir.is_dir() or package_dir.name == "chatgpt":
+            continue
+        pkgbuild = package_dir / "PKGBUILD"
+        srcinfo = package_dir / ".SRCINFO"
+        if not (pkgbuild.is_file() and srcinfo.is_file()):
+            continue
+        result = subprocess.run(
+            ["makepkg", "--printsrcinfo"],
+            cwd=package_dir,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        relative = srcinfo.relative_to(repo).as_posix()
+        if result.returncode != 0:
+            detail = result.stderr.strip() or f"makepkg exited {result.returncode}"
+            errors.append(f"{relative}: {detail}")
+            continue
+        if srcinfo.read_text(encoding="utf-8") != result.stdout:
+            errors.append(f"{relative} does not match makepkg --printsrcinfo")
+    return errors
+
+
+CATALOG_DIRECTORY = re.compile(r"^\[`(?P<name>[^`]+)`\]\((?P=name)/\)$")
+BASELINE_FIELDS = (
+    "authoritative_reference",
+    "advisory_references",
+    "divergence_notes",
+    "update_notes",
+)
+
+
+def repository_paths(repo: Path) -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return sorted(
+        repo / relative_path
+        for relative_path in result.stdout.split("\0")
+        if relative_path and (repo / relative_path).is_file()
+    )
+
+
+def check_zsh_syntax(repo: Path) -> list[str]:
+    errors: list[str] = []
+    for path in repository_paths(repo):
+        if path.suffix != ".zsh":
+            continue
+        relative = path.relative_to(repo)
+        result = subprocess.run(
+            ["zsh", "-n", relative.as_posix()],
+            cwd=repo,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            detail = result.stderr.strip().splitlines()
+            suffix = f": {detail[-1]}" if detail else ""
+            errors.append(f"{relative.as_posix()}: zsh syntax check failed{suffix}")
+    return errors
+
+
+PINNED_ACTION = re.compile(r"^[^@\s]+@[0-9a-f]{40}$")
+
+
+def mapping_values(mapping: Node | None, key: str) -> list[Node]:
+    if not isinstance(mapping, MappingNode):
+        return []
+    return [
+        value
+        for candidate, value in mapping.value
+        if isinstance(candidate, ScalarNode) and candidate.value == key
+    ]
+
+
+def workflow_action_references(document: Node | None) -> list[Node]:
+    references: list[Node] = []
+    for jobs in mapping_values(document, "jobs"):
+        if not isinstance(jobs, MappingNode):
+            continue
+        for _, job in jobs.value:
+            if not isinstance(job, MappingNode):
+                continue
+            references.extend(mapping_values(job, "uses"))
+            for steps in mapping_values(job, "steps"):
+                if not isinstance(steps, SequenceNode):
+                    continue
+                for step in steps.value:
+                    references.extend(mapping_values(step, "uses"))
+    return references
+
+
+def check_workflow_action_pins(repo: Path) -> list[str]:
+    errors: list[str] = []
+    workflows = repo / ".github/workflows"
+    if not workflows.is_dir():
+        return errors
+    for path in sorted(workflows.iterdir()):
+        if path.suffix not in {".yml", ".yaml"} or not path.is_file():
+            continue
+        relative = path.relative_to(repo).as_posix()
+        try:
+            document = yaml.compose(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError:
+            errors.append(f"{relative}: workflow YAML is invalid")
+            continue
+        for action_node in workflow_action_references(document):
+            if not isinstance(action_node, ScalarNode):
+                errors.append(f"{relative}: action reference must be a string")
+                continue
+            action = action_node.value
+            if action.startswith("./") or PINNED_ACTION.fullmatch(action):
+                continue
+            errors.append(
+                f"{relative}: action must use a full commit SHA: {action}"
+            )
+    return errors
+
+
+def catalog_rows(repo: Path) -> dict[str, list[list[str]]]:
+    rows: dict[str, list[list[str]]] = {}
+    catalog = (repo / "packages/README.md").read_text(encoding="utf-8")
+    for line in catalog.splitlines():
+        if not line.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if not cells:
+            continue
+        match = CATALOG_DIRECTORY.fullmatch(cells[0])
+        if match:
+            rows.setdefault(match.group("name"), []).append(cells)
+    return rows
+
+
+def check_catalog_coverage(repo: Path) -> list[str]:
+    errors: list[str] = []
+    rows = catalog_rows(repo)
+    package_names = package_lane_names(repo)
+    for package_name in sorted(package_names):
+        count = len(rows.get(package_name, []))
+        if count != 1:
+            errors.append(
+                "packages/README.md: "
+                f"package lane {package_name} must appear exactly once; found {count}"
+            )
+    for package_name in sorted(rows.keys() - package_names):
+        errors.append(
+            f"packages/README.md: catalog references missing package lane {package_name}"
+        )
+    return errors
+
+
+def srcinfo_identity(srcinfo: Path) -> tuple[list[str], str]:
+    values: dict[str, list[str]] = {}
+    for line in srcinfo.read_text(encoding="utf-8").splitlines():
+        if " = " not in line:
+            continue
+        key, value = line.strip().split(" = ", 1)
+        values.setdefault(key, []).append(value)
+    version = values["pkgver"][0]
+    if "epoch" in values:
+        version = f"{values['epoch'][0]}:{version}"
+    version = f"{version}-{values['pkgrel'][0]}"
+    return sorted(values.get("pkgname", [])), version
+
+
+def package_identity(repo: Path, package_name: str) -> tuple[list[str], str]:
+    package_dir = repo / "packages" / package_name
+    if package_name != "chatgpt":
+        return srcinfo_identity(package_dir / ".SRCINFO")
+    baselines = sorted(package_dir.glob("fallback-baseline-*.json"))
+    if len(baselines) != 1:
+        raise ValueError(
+            f"packages/chatgpt: expected one fallback baseline; found {len(baselines)}"
+        )
+    baseline = json.loads(baselines[0].read_text(encoding="utf-8"))
+    return [baseline["package"]["name"]], baseline["package"]["version"]
+
+
+def check_catalog_identity(repo: Path) -> list[str]:
+    errors: list[str] = []
+    for package_name, matching_rows in sorted(catalog_rows(repo).items()):
+        if len(matching_rows) != 1 or not (repo / "packages" / package_name).is_dir():
+            continue
+        if package_name != "chatgpt" and not (
+            repo / "packages" / package_name / ".SRCINFO"
+        ).is_file():
+            continue
+        row = matching_rows[0]
+        if len(row) < 3:
+            continue
+        try:
+            expected_names, expected_version = package_identity(repo, package_name)
+        except (KeyError, ValueError, json.JSONDecodeError) as error:
+            errors.append(str(error))
+            continue
+        catalog_names = sorted(re.findall(r"`([^`]+)`", row[1]))
+        if catalog_names != expected_names:
+            errors.append(
+                "packages/README.md: "
+                f"{package_name} package names {catalog_names} do not match {expected_names}"
+            )
+        if row[2] != expected_version:
+            errors.append(
+                "packages/README.md: "
+                f"{package_name} packaged version {row[2]} does not match {expected_version}"
+            )
+    return errors
+
+
+def check_catalog_shape(repo: Path) -> list[str]:
+    errors: list[str] = []
+    for package_name, matching_rows in sorted(catalog_rows(repo).items()):
+        if len(matching_rows) != 1:
+            continue
+        row = matching_rows[0]
+        if len(row) != 8:
+            errors.append(
+                f"packages/README.md: {package_name} row must contain exactly 8 columns"
+            )
+            continue
+        if any(not cell for cell in row):
+            errors.append(
+                f"packages/README.md: {package_name} row contains an empty required cell"
+            )
+        disposition = row[3]
+        if disposition not in {"accepted-current", "deferred", "retired"}:
+            errors.append(
+                f"packages/README.md: {package_name} has invalid disposition {disposition}"
+            )
+        try:
+            if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", row[5]):
+                raise ValueError
+            date.fromisoformat(row[5])
+        except ValueError:
+            errors.append(
+                f"packages/README.md: {package_name} review date must be ISO YYYY-MM-DD"
+            )
+        if row[7] not in {"yes", "no"}:
+            errors.append(
+                f"packages/README.md: {package_name} publication eligibility must be yes or no"
+            )
+        if disposition == "accepted-current" and row[7] == "no":
+            errors.append(
+                f"packages/README.md: {package_name} accepted-current lane "
+                "must be publication eligible"
+            )
+        if disposition == "retired" and row[7] == "yes":
+            errors.append(
+                f"packages/README.md: {package_name} retired lane "
+                "must not be publication eligible"
+            )
+        if disposition == "deferred" and row[7] == "yes":
+            errors.append(
+                f"packages/README.md: {package_name} deferred lane "
+                "must not be publication eligible"
+            )
+    return errors
+
+
+def baseline_value_is_present(text: str, field: str) -> bool:
+    pattern = re.compile(rf"(?m)^- `{re.escape(field)}`:\s*(?P<value>[^\n]*)$")
+    matches = list(pattern.finditer(text))
+    if len(matches) != 1:
+        return False
+    match = matches[0]
+    if match.group("value").strip():
+        return True
+    following = text[match.end() :]
+    boundary = re.search(r"(?m)^(?:- `[^`]+`:\s*|#{1,6}\s+)", following)
+    if boundary:
+        following = following[: boundary.start()]
+    return any(line.startswith(("  ", "\t")) and line.strip() for line in following.splitlines())
+
+
+def maintenance_baseline_section(text: str) -> str | None:
+    headings = list(re.finditer(r"(?m)^## Maintenance Baseline\s*$", text))
+    if len(headings) != 1:
+        return None
+    start = headings[0].end()
+    following = text[start:]
+    next_heading = re.search(r"(?m)^#{1,2}\s+", following)
+    if next_heading:
+        following = following[: next_heading.start()]
+    return following
+
+
+def check_package_baselines(repo: Path) -> list[str]:
+    errors: list[str] = []
+    for package_name, matching_rows in sorted(catalog_rows(repo).items()):
+        if len(matching_rows) != 1 or len(matching_rows[0]) != 8:
+            continue
+        disposition = matching_rows[0][3]
+        if disposition == "retired" or disposition not in {
+            "accepted-current",
+            "deferred",
+        }:
+            continue
+        readme = repo / "packages" / package_name / "README.md"
+        relative = readme.relative_to(repo).as_posix()
+        if not readme.is_file():
+            errors.append(f"{relative}: retained package lane requires a README")
+            continue
+        text = readme.read_text(encoding="utf-8")
+        baseline = maintenance_baseline_section(text)
+        if baseline is None:
+            errors.append(
+                f"{relative}: required section ## Maintenance Baseline "
+                "must appear exactly once"
+            )
+            continue
+        for field in BASELINE_FIELDS:
+            if not baseline_value_is_present(baseline, field):
+                errors.append(
+                    f"{relative}: required baseline field {field} "
+                    "must appear exactly once and be nonempty"
+                )
+    return errors
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate repository consistency")
+    parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="repository root (defaults to this checkout)",
+    )
+    parser.add_argument(
+        "--skip-tests",
+        action="store_true",
+        help="skip the committed unit-test phase during focused checker development",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo = args.repo.resolve()
+    if not (repo / ".git").exists():
+        print(f"repository consistency: not a Git checkout: {repo}", file=sys.stderr)
+        return 2
+
+    if not args.skip_tests:
+        result = subprocess.run(
+            [sys.executable, "-m", "unittest", "discover", "-v"],
+            cwd=repo,
+            check=False,
+        )
+        if result.returncode != 0:
+            return result.returncode
+
+    errors = check_package_pairs(repo)
+    errors.extend(check_srcinfo(repo))
+    errors.extend(check_catalog_coverage(repo))
+    errors.extend(check_catalog_identity(repo))
+    errors.extend(check_catalog_shape(repo))
+    errors.extend(check_package_baselines(repo))
+    errors.extend(check_zsh_syntax(repo))
+    errors.extend(check_workflow_action_pins(repo))
+    if errors:
+        for error in errors:
+            print(f"repository consistency: {error}", file=sys.stderr)
+        return 1
+
+    print("repository consistency: passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<details>
<summary><picture><img alt="DIFF" src="https://img.shields.io/badge/DIFF-57606A?style=for-the-badge" height="16"></picture>&nbsp;<picture><img alt="IMPL: 505 additions, 0 deletions" src="https://img.shields.io/badge/IMPL-%2B505%20%E2%88%920-0969DA?style=flat" height="16"></picture> <picture><img alt="TEST: 756 additions, 1 deletions" src="https://img.shields.io/badge/TEST-%2B756%20%E2%88%921-6F5F9A?style=flat" height="16"></picture> <picture><img alt="DOC: 424 additions, 113 deletions" src="https://img.shields.io/badge/DOC-%2B424%20%E2%88%92113-3F7770?style=flat" height="16"></picture> <picture><img alt="FILES: 22 touched" src="https://img.shields.io/badge/FILES-22-5F6B78?style=flat" height="16"></picture></summary>

- <picture><img alt="IMPL: 505 additions, 0 deletions" src="https://img.shields.io/badge/IMPL-%2B505%20%E2%88%920-0969DA?style=flat" height="16"></picture> <picture><img alt="FILES: 2 implementation files" src="https://img.shields.io/badge/FILES-2-5F6B78?style=flat" height="16"></picture>
  - [`.github/workflows/repository-consistency.yml`](https://github.com/nisavid/arch-pkgs/pull/35/files#diff-ee4c1cd1ed37ae99825a5ad206a51ecf44915c7d7b5c992203a0f6d30dbf9f69) <picture><img alt="56 additions, 0 deletions" title="56 additions, 0 deletions" src="https://img.shields.io/badge/%2B56-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`tools/check_repo_consistency.py`](https://github.com/nisavid/arch-pkgs/pull/35/files#diff-6945107b9e6bb56b260fc8074fd72f4686df2d46b6405f7c60d04d9a2790788e) <picture><img alt="449 additions, 0 deletions" title="449 additions, 0 deletions" src="https://img.shields.io/badge/%2B449-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
- <picture><img alt="TEST: 756 additions, 1 deletions" src="https://img.shields.io/badge/TEST-%2B756%20%E2%88%921-6F5F9A?style=flat" height="16"></picture> <picture><img alt="FILES: 2 test files" src="https://img.shields.io/badge/FILES-2-5F6B78?style=flat" height="16"></picture>
  - [`tests/test_ingest_chatgpt_linux.py`](https://github.com/nisavid/arch-pkgs/pull/35/files#diff-1a07f612873c901dd40853981cb385a96a9c9476d226a35c24eb63396b56e476) <picture><img alt="19 additions, 1 deletions" title="19 additions, 1 deletions" src="https://img.shields.io/badge/%2B19-%E2%88%921-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`tests/test_repo_consistency.py`](https://github.com/nisavid/arch-pkgs/pull/35/files#diff-d55d28108765611788cd1fe80e50c15a8e7113e3c70a609978e897a55a7eae82) <picture><img alt="737 additions, 0 deletions" title="737 additions, 0 deletions" src="https://img.shields.io/badge/%2B737-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
- <picture><img alt="DOC: 424 additions, 113 deletions" src="https://img.shields.io/badge/DOC-%2B424%20%E2%88%92113-3F7770?style=flat" height="16"></picture> <picture><img alt="FILES: 18 documentation files" src="https://img.shields.io/badge/FILES-18-5F6B78?style=flat" height="16"></picture>
  - [`README.md`](https://github.com/nisavid/arch-pkgs/pull/35/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) <picture><img alt="4 additions, 2 deletions" title="4 additions, 2 deletions" src="https://img.shields.io/badge/%2B4-%E2%88%922-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`docs/policies/reference-packages.md`](https://github.com/nisavid/arch-pkgs/pull/35/files#diff-9d344a74d7ef4e5df73f5f931e46eb2b66204a35b7ab3d8f284723fb11aff60e) <picture><img alt="35 additions, 10 deletions" title="35 additions, 10 deletions" src="https://img.shields.io/badge/%2B35-%E2%88%9210-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`packages/README.md`](https://github.com/nisavid/arch-pkgs/pull/35/files#diff-1206c4b8d1f7e37d1a4079860d4b24c3178398a059b3bd4c0df5c40fabaab45a) <picture><img alt="52 additions, 28 deletions" title="52 additions, 28 deletions" src="https://img.shields.io/badge/%2B52-%E2%88%9228-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`packages/chatgpt/README.md`](https://github.com/nisavid/arch-pkgs/pull/35/files#diff-5c9e03ddfd39b2eedc40b3f9aee9fc7436e58d9f57c6633f909e40b3807c4074) <picture><img alt="1 additions, 1 deletions" title="1 additions, 1 deletions" src="https://img.shields.io/badge/%2B1-%E2%88%921-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`packages/ctranslate2/README.md`](https://github.com/nisavid/arch-pkgs/pull/35/files#diff-36d228d640b7b425e9c5e848b09fc88d00c0e0238a2aace545cdc20f87451f5c) <picture><img alt="24 additions, 14 deletions" title="24 additions, 14 deletions" src="https://img.shields.io/badge/%2B24-%E2%88%9214-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`packages/hayhooks/README.md`](https://github.com/nisavid/arch-pkgs/pull/35/files#diff-13b2b04d48bfe6d723d485aba7af50a994cba62e312c7c767a0908b76cc11074) <picture><img alt="20 additions, 0 deletions" title="20 additions, 0 deletions" src="https://img.shields.io/badge/%2B20-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`packages/haystack-ai/README.md`](https://github.com/nisavid/arch-pkgs/pull/35/files#diff-ec110838323a11768b0c7af93035dfa4895a988bd24230915a0650518530a72c) <picture><img alt="20 additions, 0 deletions" title="20 additions, 0 deletions" src="https://img.shields.io/badge/%2B20-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`packages/open-webui/README.md`](https://github.com/nisavid/arch-pkgs/pull/35/files#diff-7640f162156acc3852c2979e3c4c4824dc9a15fa28b97eead0b549fb37296b96) <picture><img alt="45 additions, 22 deletions" title="45 additions, 22 deletions" src="https://img.shields.io/badge/%2B45-%E2%88%9222-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`packages/python-backoff/README.md`](https://github.com/nisavid/arch-pkgs/pull/35/files#diff-5ae67056e25f4a20f2eb55d28ef67b226c5cf6d0164ce2d6974a6214f6ba5e91) <picture><img alt="17 additions, 0 deletions" title="17 additions, 0 deletions" src="https://img.shields.io/badge/%2B17-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`packages/python-docstring-parser/README.md`](https://github.com/nisavid/arch-pkgs/pull/35/files#diff-a06909fb51471872ec64919387145dd1727bff11ae60fd1df89f762c6d4a1aea) <picture><img alt="18 additions, 0 deletions" title="18 additions, 0 deletions" src="https://img.shields.io/badge/%2B18-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`packages/python-fastapi-openai-compat/README.md`](https://github.com/nisavid/arch-pkgs/pull/35/files#diff-1aa8759166f56ecc806206b6814d2bdf971fbd789f55bcc66dfc042b5c7feced) <picture><img alt="20 additions, 0 deletions" title="20 additions, 0 deletions" src="https://img.shields.io/badge/%2B20-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`packages/python-faster-whisper/README.md`](https://github.com/nisavid/arch-pkgs/pull/35/files#diff-271577ab3fda61a85e61e52f05f0fda872d4efa89b8062eacead939695b29047) <picture><img alt="21 additions, 9 deletions" title="21 additions, 9 deletions" src="https://img.shields.io/badge/%2B21-%E2%88%929-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`packages/python-lazy-imports/README.md`](https://github.com/nisavid/arch-pkgs/pull/35/files#diff-971c80c9a2f997dab8d4f7eeb38c5a07015a88ef61aa48a3552820c37c3f05c8) <picture><img alt="18 additions, 0 deletions" title="18 additions, 0 deletions" src="https://img.shields.io/badge/%2B18-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`packages/python-posthog/README.md`](https://github.com/nisavid/arch-pkgs/pull/35/files#diff-2c9b4b901651b58831b6932874f5c3929ba322d97644026120bad55de18b81f6) <picture><img alt="21 additions, 0 deletions" title="21 additions, 0 deletions" src="https://img.shields.io/badge/%2B21-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`packages/python-sentence-transformers/README.md`](https://github.com/nisavid/arch-pkgs/pull/35/files#diff-9a81661076c4cf3b99973d92bfba336a09fa05aee4e95c75fa08a4710d924ed9) <picture><img alt="25 additions, 8 deletions" title="25 additions, 8 deletions" src="https://img.shields.io/badge/%2B25-%E2%88%928-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`packages/qdrant/README.md`](https://github.com/nisavid/arch-pkgs/pull/35/files#diff-9dbf354487d813328786e32c00438184aaa8933c0e14e91ef41a6b3cd8d5eca2) <picture><img alt="21 additions, 0 deletions" title="21 additions, 0 deletions" src="https://img.shields.io/badge/%2B21-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`packages/thorium-browser-updated/README.md`](https://github.com/nisavid/arch-pkgs/pull/35/files#diff-e7f2716b489047c44992ff6cf56ead87c3a6929734ff814a8228af19d5e150d4) <picture><img alt="42 additions, 19 deletions" title="42 additions, 19 deletions" src="https://img.shields.io/badge/%2B42-%E2%88%9219-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`packages/utilyze/README.md`](https://github.com/nisavid/arch-pkgs/pull/35/files#diff-684275bc4dd4b6f37a5a1ff7e4982a94a9202fe6d53bca9bc32e1ab4832390e3) <picture><img alt="20 additions, 0 deletions" title="20 additions, 0 deletions" src="https://img.shields.io/badge/%2B20-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>

</details>

## Summary

Implements the repository-admission safeguards selected in [#24](https://github.com/nisavid/arch-pkgs/issues/24) as the first dependency in the completed refresh sequence from [#32](https://github.com/nisavid/arch-pkgs/issues/32).

## Changes

- Adds one unfiltered, read-only `Repository consistency` job for pull requests and pushes to `main`; its checker runs as an unprivileged Arch user.
- Bounds Arch dependency bootstrap to four forced-resynchronization attempts so mirror publication windows do not fail the gate on the first missing payload.
- Enforces committed tests, exact `.SRCINFO` regeneration, package-catalog coverage and identity, retained-lane baseline shape, Zsh syntax, and structurally parsed full-SHA workflow action references.
- Replaces the stale inventory with the dated 17-lane refresh index and backfills or reconciles every retained maintenance baseline without promoting any deferred lane.
- Makes the existing signal/lock fixture independent of stock Arch's default debug-package setting.

## Verification

- `python3 -B tools/check_repo_consistency.py` — 107 tests passed; structural check passed.
- `git diff --check origin/main...HEAD` — passed.
- Independent specification and implementation reviews — clean.
- `actionlint -verbose` — zero workflow errors.

## Bootstrap

This PR intentionally does not change the active branch ruleset. After rebase merge, wait for the exact merged `main` push to report `Repository consistency` successfully; only then add that exact GitHub Actions context as a no-bypass required status check. This preserves the existing approval, stale-review dismissal, last-push approval, thread-resolution, scanning, and automated-review rules.
